### PR TITLE
🎨 Palette: Add accessible labels and tooltips to time entry list actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-13 - [Tooltip on Disabled Buttons]
+**Learning:** Mantine tooltips on disabled ActionIcons require a wrapper (e.g., div or Box) to capture mouse events.
+**Action:** When adding tooltips to buttons that can be disabled, always wrap them in an inline-block container.

--- a/frontend/src/components/lists/TimeEntryList.tsx
+++ b/frontend/src/components/lists/TimeEntryList.tsx
@@ -1,4 +1,4 @@
-import { Table, Center, Loader, Text, Group, ActionIcon, Badge, Select } from '@mantine/core';
+import { Table, Center, Loader, Text, Group, ActionIcon, Badge, Select, Tooltip } from '@mantine/core';
 import { IconEdit, IconTrash } from '@tabler/icons-react';
 import { DateTime } from 'luxon';
 import { Pagination } from '../common/Pagination';
@@ -135,24 +135,34 @@ export function TimeEntryList({
                   <Table.Td>
                     <Group justify="flex-end" gap="xs">
                       {onEdit && (
-                        <ActionIcon
-                          variant="light"
-                          color="blue"
-                          onClick={() => onEdit(entry)}
-                          disabled={entry.isInvoiced}
-                        >
-                          <IconEdit size={16} />
-                        </ActionIcon>
+                        <Tooltip label={entry.isInvoiced ? 'Cannot edit invoiced entry' : 'Edit time entry'}>
+                          <div style={{ display: 'inline-block' }}>
+                            <ActionIcon
+                              variant="light"
+                              color="blue"
+                              onClick={() => onEdit(entry)}
+                              disabled={entry.isInvoiced}
+                              aria-label="Edit time entry"
+                            >
+                              <IconEdit size={16} />
+                            </ActionIcon>
+                          </div>
+                        </Tooltip>
                       )}
                       {onDelete && (
-                        <ActionIcon
-                          variant="light"
-                          color="red"
-                          onClick={() => onDelete(entry)}
-                          disabled={entry.isInvoiced}
-                        >
-                          <IconTrash size={16} />
-                        </ActionIcon>
+                        <Tooltip label={entry.isInvoiced ? 'Cannot delete invoiced entry' : 'Delete time entry'}>
+                          <div style={{ display: 'inline-block' }}>
+                            <ActionIcon
+                              variant="light"
+                              color="red"
+                              onClick={() => onDelete(entry)}
+                              disabled={entry.isInvoiced}
+                              aria-label="Delete time entry"
+                            >
+                              <IconTrash size={16} />
+                            </ActionIcon>
+                          </div>
+                        </Tooltip>
                       )}
                     </Group>
                   </Table.Td>


### PR DESCRIPTION
🎨 Palette: Add accessible labels and tooltips to time entry list actions

💡 **What:**
- Added `aria-label` to the "Edit" and "Delete" buttons in the Time Entry list.
- Wrapped these buttons in a `Tooltip` component.
- Added logic to show different tooltip text based on the entry's status (e.g., "Cannot edit invoiced entry" vs "Edit time entry").
- Wrapped the buttons in a `div` to ensure tooltips appear even when the buttons are disabled.
- Added `.Jules/palette.md` to document critical UX learnings.

🎯 **Why:**
- **Accessibility:** Screen reader users could not identify the purpose of the icon-only buttons.
- **Usability:** Users could not understand why certain actions were disabled (grayed out) without feedback. The tooltip now clarifies that invoiced entries cannot be modified.

📸 **Before/After:**
*(See attached screenshots in verification steps)*

♿ **Accessibility:**
- Added `aria-label` for screen readers.
- Ensured tooltips are accessible via hover (and focus for enabled elements).


---
*PR created automatically by Jules for task [2938822805906734089](https://jules.google.com/task/2938822805906734089) started by @joelmnz*