### PR TITLE
Refactor Settings into Company, Invoice, and API Key tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 # Database
+data/
 *.db
 *.db-shm
 *.db-wal

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,26 +1,147 @@
 # Agent Guidelines
 
 ## Build/Lint/Test Commands
-- **Backend Build**: `cd backend && bun run build` (TypeScript compilation, no linter)
-- **Frontend Build**: `cd frontend && bun run build` (Vite build, no linter)
-- **Backend Dev**: `cd backend && bun run dev` (bun watch on localhost:8080)
+- **Backend Build**: `cd backend && bun run build` (TypeScript compilation via `tsc`, no linter configured)
+- **Frontend Build**: `cd frontend && bun run build` (Vite production build)
+- **Frontend Type Check**: `cd frontend && npx tsc --noEmit` (type check without emitting)
+- **Backend Dev**: `cd backend && bun run dev` (bun --watch on localhost:8080)
 - **Frontend Dev**: `cd frontend && bun run dev` (Vite on localhost:5173)
-- **Backend Tests**: `cd backend && bun run test` (runs sequential test suite via test-sequential.sh)
+- **Backend Tests**: `cd backend && bun run test` (sequential via `test-sequential.sh`, shared DB)
 - **Single Backend Test**: `cd backend && bun test --preload ./src/tests/setup.ts src/tests/<filename>.test.ts`
 - **Single Frontend Test**: `cd frontend && bun run test <filename>`
 - **Test UI** (frontend only): `cd frontend && bun run test:ui`
+- **E2E Tests**: `bun run test:e2e` (Playwright, from project root, auto-starts servers)
+- **E2E Headed**: `bun run test:e2e:headed`
 - **DB Migrations**: `cd backend && bun run db:generate && bun run db:migrate`
-- **E2E Tests**: `bun run test:e2e` (Playwright, from project root)
+- **DB Seed**: `cd backend && bun run db:seed`
+- **Precommit**: `bun run precommit` (runs backend tsc, frontend tsc --noEmit, frontend vite build, Docker build)
+
+## Project Structure
+- **Monorepo**: `backend/` (Express API) + `frontend/` (React SPA) + `e2e/` (Playwright)
+- **Runtime**: Bun for both backend and frontend
+- **Package Manager**: Bun (lockfile: `bun.lockb`)
+- **Backend**: Express 5 + Drizzle ORM (SQLite) + Zod validation + Luxon dates
+- **Frontend**: React 19 + Mantine 8 + React Router v7 + TanStack Query + Vitest
+- **Auth**: Session-based (express-session + connect-sqlite3), single-user via env vars
 
 ## Code Style
-- **Indentation**: 2 spaces (enforced by .editorconfig), LF line endings
-- **Imports**: ESM only (`import`/`export`), **MUST** use `.js` extensions in backend imports
-- **Types**: Strict TypeScript, infer from Drizzle schemas (`$inferSelect`/`$inferInsert`) or Zod validators
-- **Naming**: camelCase for variables/functions, PascalCase for components/types/interfaces
-- **Validation**: Use Zod schemas in `backend/src/types/validation.ts`, parse in route handlers
-- **Error Handling**: Use centralized `errorHandler` middleware, throw errors in routes, pass to `next()`
-- **Date/Time**: Use Luxon (backend/frontend), ISO 8601 strings for API/DB (TEXT columns)
-- **Database**: Drizzle ORM with SQLite, use types from `db/schema.ts`, cascade deletes configured
-- **API**: Express routes in `backend/src/routes/`, service layer in `services/` for PDF/CSV
-- **Frontend**: Mantine UI components, React Router v7, TanStack Query for data fetching
-- **Package Manager**: Bun for both backend and frontend
+
+### Formatting
+- **Indentation**: 2 spaces (enforced by `.editorconfig`), LF line endings
+- **Final newline**: Required (`.editorconfig`)
+- **No linter/formatter tool** configured (no ESLint, no Prettier)
+
+### Imports
+- **ESM only** (`import`/`export`) throughout — both packages have `"type": "module"`
+- **Backend imports MUST use `.js` extensions** (TypeScript compiles to ESM, Node requires extensions):
+  ```typescript
+  import { db } from '../db/index.js';           // CORRECT
+  import { requireAuth } from '../middleware/auth.js'; // CORRECT
+  import { db } from '../db/index';              // WRONG - runtime error
+  ```
+- **Frontend imports do NOT need extensions** (Vite/bundler resolves them)
+
+### TypeScript
+- **Strict mode** enabled in both `tsconfig.json` files
+- **Backend**: target ES2022, module ESNext, moduleResolution node, `bun-types` included
+- **Frontend**: target ES2020, moduleResolution bundler, `noUnusedLocals` + `noUnusedParameters` enabled
+- **Never suppress errors** with `as any`, `@ts-ignore`, or `@ts-expect-error`
+
+### Naming
+- **camelCase** for variables, functions, route handlers, database column aliases
+- **PascalCase** for React components, types, interfaces, Zod schema names
+- **Database columns**: snake_case in SQL, camelCase in Drizzle schema definitions
+
+### Types
+- **Infer from Drizzle schemas** using `$inferSelect` / `$inferInsert` (never duplicate types):
+  ```typescript
+  export type Client = typeof clients.$inferSelect;
+  export type NewClient = typeof clients.$inferInsert;
+  ```
+- **Validation schemas** in `backend/src/types/validation.ts` using Zod — parse in route handlers:
+  ```typescript
+  const result = createClientSchema.parse(req.body); // Throws ZodError on failure
+  ```
+- **Frontend types** in `frontend/src/types/index.ts`, shared via `import type`
+
+### Error Handling
+- **Backend routes**: Wrap handler body in `try/catch`, pass errors to `next()`:
+  ```typescript
+  router.get('/', requireAuth, async (req, res, next) => {
+    try {
+      // ... handler logic
+      res.json(data);
+    } catch (err) { next(err); }
+  });
+  ```
+- **Centralized error handler** in `backend/src/middleware/errorHandler.ts` handles:
+  - `ZodError` → 400 with validation details
+  - `UNIQUE constraint failed` → 409
+  - Everything else → 500
+- **Never send error responses directly in routes** — always throw or `next(err)`
+
+### Date/Time
+- **Always use Luxon** (`DateTime`) for date operations, never raw `Date` for display
+- **API/DB format**: ISO 8601 TEXT strings (`YYYY-MM-DD` or full timestamp)
+- **Default timezone**: `Pacific/Auckland`, configurable via `TZ` env var
+- **Utilities**: `backend/src/utils/time.ts` — `roundUpToSixMinutes()`, `calculateDueDate()`, `getCurrentTimestamp()`
+
+## Database
+- **Drizzle ORM with SQLite** (via `bun:sqlite`)
+- **Schema**: `backend/src/db/schema.ts` — all tables, types, indexes, foreign keys
+- **Cascade deletes** configured: deleting client cascades to projects → time entries, expenses, invoices
+- **Migration workflow**: Edit schema → `bun run db:generate` → review SQL in `backend/drizzle/` → `bun run db:migrate`
+- **Settings**: Singleton row (`id=1`), seeded on first migration
+- **Date columns**: Stored as TEXT (ISO 8601), not INTEGER timestamps
+
+## API Patterns
+- **Routes** in `backend/src/routes/`, one file per resource (clients, projects, timeEntries, etc.)
+- **Auth middleware**: `requireAuth` from `middleware/auth.ts` on all non-auth routes
+- **Pagination**: Query params `page` (1-indexed), `page_size` (10/25/50/100)
+- **Filtering**: Resource-specific query params (`status`, `clientId`, `from`, `to`)
+- **Response format**: `{ data: [...], pagination: { page, pageSize, total, totalPages } }`
+- **Service layer**: `backend/src/services/` for PDF (`pdfmake`) and CSV generation
+
+## Frontend Patterns
+- **UI library**: Mantine 8 components and hooks (`@mantine/core`, `@mantine/form`, `@mantine/dates`)
+- **Icons**: `@tabler/icons-react`
+- **Data fetching**: TanStack Query (`useQuery`, `useMutation`) with API services in `frontend/src/services/api.ts`
+- **Routing**: React Router v7 (`react-router-dom`)
+- **Auth context**: `frontend/src/contexts/AuthContext.tsx` — wraps app, provides `user`, `login()`, `logout()`
+- **Timer context**: `frontend/src/contexts/TimerContext.tsx` — offline support via IndexedDB
+- **Forms**: Mantine `useForm` hook with inline validation
+
+## Testing
+- **Backend tests**: Vitest + Supertest, sequential execution required (shared SQLite test DB)
+  - Setup in `backend/src/tests/setup.ts` creates fresh DB, runs migrations, seeds settings
+  - Test DB path: `backend/data/test/app.test.db` (isolated from dev `app.db`)
+  - Tests: auth, settings, clients, projects, import, invoices, client-invoices
+  - Helper utilities in `backend/src/tests/helpers.ts`
+- **Frontend tests**: Vitest with jsdom environment
+- **E2E tests**: Playwright in `e2e/`, fresh DB per run (`backend/data/e2e-test.db`)
+  - Use `authenticatedPage` fixture from `e2e/fixtures/helpers.ts`
+  - Test data prefixed with `E2E-` for identification
+
+## Key Files Reference
+- **Schema**: `backend/src/db/schema.ts` — all tables, types, foreign keys
+- **Validation**: `backend/src/types/validation.ts` — all Zod schemas
+- **Error handler**: `backend/src/middleware/errorHandler.ts`
+- **Auth**: `backend/src/routes/auth.ts` + `backend/src/middleware/auth.ts`
+- **API client**: `frontend/src/services/api.ts` — all frontend API calls
+- **Frontend types**: `frontend/src/types/index.ts`
+- **Invoice logic**: `backend/src/routes/invoices.ts` — complex transaction logic
+- **PDF service**: `backend/src/services/pdf.ts` — pdfmake with Markdown footer
+- **Timer offline**: `frontend/src/utils/timerDb.ts` — IndexedDB persistence
+- **Test setup**: `backend/src/tests/setup.ts`
+
+## Common Gotchas
+1. **Backend imports MUST use `.js` extension** even in `.ts` files — ESM requirement, will fail at runtime without it
+2. **Backend tests must run sequentially** — they share a test DB; use `bun run test` (not `bun test` directly for all)
+3. **Time entry rounding**: `roundUpToSixMinutes()` rounds to 0.1 hour increments (6-minute blocks)
+4. **Invoice number auto-increment**: Managed by `settings.nextInvoiceNumber`, updated atomically in transaction
+5. **Cascade deletes are configured** — deleting a client deletes all its projects, time entries, expenses, invoices
+6. **Session cookies**: `secure: 'auto'`, `trust proxy` enabled for Cloudflare tunnels
+7. **PDF generation**: Uses pdfmake with embedded Roboto fonts via `vfs_fonts.js`, JSDOM for Markdown rendering
+8. **Template variables** in invoice footer: `{{invoice_number}}`, `{{due_date}}`, `{{total_amount}}`, `{{client_name}}`
+9. **Frontend has `noUnusedLocals`/`noUnusedParameters`** enabled — remove unused imports/vars or build fails
+10. **Express 5** is used (not 4) — async error handling differs slightly from Express 4

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ FROM oven/bun:latest AS runtime
 
 # Create non-root user with UNRAID compatible IDs (GID 100 already exists as 'users')
 # Container runs as UID 99, GID 100 - ensure host data directory has matching ownership
-RUN adduser --system --uid 99 --ingroup users bunuser
+# Note: using useradd instead of adduser (not available in Debian 13 trixie base)
+RUN useradd --system --uid 99 --gid 100 --no-create-home bunuser
 
 ENV NODE_ENV=production
 WORKDIR /app

--- a/backend/drizzle/0003_shiny_api_keys.sql
+++ b/backend/drizzle/0003_shiny_api_keys.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `api_keys` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `name` text DEFAULT 'Default API Key' NOT NULL,
+  `key_hash` text NOT NULL,
+  `key_prefix` text NOT NULL,
+  `key_last_four` text NOT NULL,
+  `created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  `last_used_at` text,
+  `revoked_at` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `api_keys_key_hash_unique` ON `api_keys` (`key_hash`);
+--> statement-breakpoint
+CREATE INDEX `api_keys_active_idx` ON `api_keys` (`revoked_at`);

--- a/backend/drizzle/0004_smiling_randall.sql
+++ b/backend/drizzle/0004_smiling_randall.sql
@@ -1,0 +1,23 @@
+DROP INDEX IF EXISTS `api_keys_active_idx`;
+--> statement-breakpoint
+CREATE TABLE `api_keys_new` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`key_hash` text NOT NULL,
+	`key_prefix` text NOT NULL,
+	`key_last_four` text NOT NULL,
+	`created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`last_used_at` text
+);
+--> statement-breakpoint
+INSERT INTO `api_keys_new` (`id`, `name`, `key_hash`, `key_prefix`, `key_last_four`, `created_at`, `last_used_at`)
+SELECT `id`, `name`, `key_hash`, `key_prefix`, `key_last_four`, `created_at`, `last_used_at`
+FROM `api_keys` WHERE `revoked_at` IS NULL;
+--> statement-breakpoint
+DROP TABLE `api_keys`;
+--> statement-breakpoint
+ALTER TABLE `api_keys_new` RENAME TO `api_keys`;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `api_keys_name_unique` ON `api_keys` (`name`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `api_keys_key_hash_unique` ON `api_keys` (`key_hash`);

--- a/backend/drizzle/meta/0004_snapshot.json
+++ b/backend/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,905 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b346b653-4640-4ce5-88f8-11e11d2c53e2",
+  "prevId": "9a6a7166-f616-469a-9877-3f079d43c282",
+  "tables": {
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_last_four": {
+          "name": "key_last_four",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_name_unique": {
+          "name": "api_keys_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "clients": {
+      "name": "clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invoice_email": {
+          "name": "invoice_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact_person": {
+          "name": "contact_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_hourly_rate": {
+          "name": "default_hourly_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "expenses": {
+      "name": "expenses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expense_date": {
+          "name": "expense_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_billable": {
+          "name": "is_billable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_invoiced": {
+          "name": "is_invoiced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "expenses_project_invoiced_idx": {
+          "name": "expenses_project_invoiced_idx",
+          "columns": [
+            "project_id",
+            "is_invoiced"
+          ],
+          "isUnique": false
+        },
+        "expenses_expense_date_idx": {
+          "name": "expenses_expense_date_idx",
+          "columns": [
+            "expense_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "expenses_project_id_projects_id_fk": {
+          "name": "expenses_project_id_projects_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "expenses_invoice_id_invoices_id_fk": {
+          "name": "expenses_invoice_id_invoices_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invoice_line_items": {
+      "name": "invoice_line_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "linked_time_entry_id": {
+          "name": "linked_time_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "linked_expense_id": {
+          "name": "linked_expense_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "invoice_line_items_invoice_id_idx": {
+          "name": "invoice_line_items_invoice_id_idx",
+          "columns": [
+            "invoice_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invoice_line_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_line_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_line_items_linked_time_entry_id_time_entries_id_fk": {
+          "name": "invoice_line_items_linked_time_entry_id_time_entries_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "time_entries",
+          "columnsFrom": [
+            "linked_time_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invoice_line_items_linked_expense_id_expenses_id_fk": {
+          "name": "invoice_line_items_linked_expense_id_expenses_id_fk",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "expenses",
+          "columnsFrom": [
+            "linked_expense_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invoices": {
+      "name": "invoices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_invoiced": {
+          "name": "date_invoiced",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total": {
+          "name": "total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date_sent": {
+          "name": "date_sent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date_paid": {
+          "name": "date_paid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "invoices_number_unique": {
+          "name": "invoices_number_unique",
+          "columns": [
+            "number"
+          ],
+          "isUnique": true
+        },
+        "invoices_date_invoiced_idx": {
+          "name": "invoices_date_invoiced_idx",
+          "columns": [
+            "date_invoiced"
+          ],
+          "isUnique": false
+        },
+        "invoices_status_due_date_idx": {
+          "name": "invoices_status_due_date_idx",
+          "columns": [
+            "status",
+            "due_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_project_id_projects_id_fk": {
+          "name": "invoices_project_id_projects_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hourly_rate": {
+          "name": "hourly_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "projects_client_active_idx": {
+          "name": "projects_client_active_idx",
+          "columns": [
+            "client_id",
+            "active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "projects_client_id_clients_id_fk": {
+          "name": "projects_client_id_clients_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Example Company'"
+        },
+        "company_address": {
+          "name": "company_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "company_email": {
+          "name": "company_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "company_phone": {
+          "name": "company_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "invoice_footer_markdown": {
+          "name": "invoice_footer_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "next_invoice_number": {
+          "name": "next_invoice_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "time_entries": {
+      "name": "time_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_hours": {
+          "name": "total_hours",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_invoiced": {
+          "name": "is_invoiced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "time_entries_project_invoiced_idx": {
+          "name": "time_entries_project_invoiced_idx",
+          "columns": [
+            "project_id",
+            "is_invoiced"
+          ],
+          "isUnique": false
+        },
+        "time_entries_start_at_idx": {
+          "name": "time_entries_start_at_idx",
+          "columns": [
+            "start_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "time_entries_project_id_projects_id_fk": {
+          "name": "time_entries_project_id_projects_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_entries_invoice_id_invoices_id_fk": {
+          "name": "time_entries_invoice_id_invoices_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1770840848440,
       "tag": "0003_shiny_api_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1770845925873,
+      "tag": "0004_smiling_randall",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1763580773990,
       "tag": "0002_whole_vertigo",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1770840848440,
+      "tag": "0003_shiny_api_keys",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -43,6 +43,7 @@
     "start": "bun run dist/index.js",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "bun run src/db/migrate.ts",
+    "db:seed": "bun run seed-data.ts",
     "test": "./test-sequential.sh",
     "test:parallel": "bun test",
     "test:watch": "bun test --watch"

--- a/backend/seed-data.ts
+++ b/backend/seed-data.ts
@@ -1,76 +1,143 @@
-import { db } from './src/db/index.js';
-import { clients, projects, invoices } from './src/db/schema.js';
+import { db, sqlite } from './src/db/index.js';
+import { clients, projects, invoices, settings, type NewInvoice } from './src/db/schema.js';
+import { eq } from 'drizzle-orm';
 
 async function seedData() {
-  // Create a test client
-  const [client] = await db.insert(clients).values({
-    name: 'Test Client',
-    email: 'test@example.com',
-    defaultHourlyRate: 100,
-  }).returning();
+  try {
+    // Check if tables exist
+    const clientTableExists = sqlite.query("SELECT name FROM sqlite_master WHERE type='table' AND name='clients'").get();
+    if (!clientTableExists) {
+      console.error('❌ Error: Database tables not found. Please run migrations first:');
+      console.error('bun run db:migrate');
+      process.exit(1);
+    }
 
-  // Create a test project
-  const [project] = await db.insert(projects).values({
-    clientId: client.id,
-    name: 'Test Project',
-    hourlyRate: 100,
-  }).returning();
+    console.log('🌱 Seeding data...');
 
-  // Create invoices with various dates
-  
-  // Invoice from last financial year (before April 1, 2024)
-  await db.insert(invoices).values({
-    number: 'INV-0001',
-    clientId: client.id,
-    projectId: project.id,
-    dateInvoiced: '2024-02-15',
-    dueDate: '2024-03-20',
-    status: 'Paid',
-    subtotal: 1000,
-    total: 1000,
-    datePaid: '2024-03-01',
-  });
+    // 1. Get or Create Test Client
+    let client = await db.query.clients.findFirst({
+      where: eq(clients.email, 'test@example.com'),
+    });
 
-  // Invoice from current financial year (after April 1, 2024)
-  await db.insert(invoices).values({
-    number: 'INV-0002',
-    clientId: client.id,
-    projectId: project.id,
-    dateInvoiced: '2024-05-10',
-    dueDate: '2024-06-20',
-    status: 'Paid',
-    subtotal: 2000,
-    total: 2000,
-    datePaid: '2024-06-05',
-  });
+    if (!client) {
+      console.log('Creating Test Client...');
+      const results = await db.insert(clients).values({
+        name: 'Test Client',
+        email: 'test@example.com',
+        defaultHourlyRate: 100,
+      }).returning();
+      client = results[0];
+    } else {
+      console.log('Test Client already exists.');
+    }
 
-  // Recent invoice
-  await db.insert(invoices).values({
-    number: 'INV-0003',
-    clientId: client.id,
-    projectId: project.id,
-    dateInvoiced: '2024-10-01',
-    dueDate: '2024-11-20',
-    status: 'Sent',
-    subtotal: 3000,
-    total: 3000,
-  });
+    // 2. Get or Create Test Project
+    let project = await db.query.projects.findFirst({
+      where: eq(projects.clientId, client.id),
+    });
 
-  // Very recent paid invoice
-  await db.insert(invoices).values({
-    number: 'INV-0004',
-    clientId: client.id,
-    projectId: project.id,
-    dateInvoiced: '2024-11-05',
-    dueDate: '2024-12-20',
-    status: 'Paid',
-    subtotal: 1500,
-    total: 1500,
-    datePaid: '2024-11-08',
-  });
+    if (!project) {
+      console.log('Creating Test Project...');
+      const results = await db.insert(projects).values({
+        clientId: client.id,
+        name: 'Test Project',
+        hourlyRate: 100,
+      }).returning();
+      project = results[0];
+    } else {
+      console.log('Test Project already exists.');
+    }
 
-  console.log('Test data seeded successfully!');
-  process.exit(0);
+    // 3. Create Invoices (Upsert based on number)
+    const invoicesData: NewInvoice[] = [
+      {
+        number: 'INV-0001',
+        clientId: client.id,
+        projectId: project.id,
+        dateInvoiced: '2024-02-15',
+        dueDate: '2024-03-20',
+        status: 'Paid',
+        subtotal: 1000,
+        total: 1000,
+        datePaid: '2024-03-01',
+      },
+      {
+        number: 'INV-0002',
+        clientId: client.id,
+        projectId: project.id,
+        dateInvoiced: '2024-05-10',
+        dueDate: '2024-06-20',
+        status: 'Paid',
+        subtotal: 2000,
+        total: 2000,
+        datePaid: '2024-06-05',
+      },
+      {
+        number: 'INV-0003',
+        clientId: client.id,
+        projectId: project.id,
+        dateInvoiced: '2024-10-01',
+        dueDate: '2024-11-20',
+        status: 'Sent',
+        subtotal: 3000,
+        total: 3000,
+      },
+      {
+        number: 'INV-0004',
+        clientId: client.id,
+        projectId: project.id,
+        dateInvoiced: '2024-11-05',
+        dueDate: '2024-12-20',
+        status: 'Paid',
+        subtotal: 1500,
+        total: 1500,
+        datePaid: '2024-11-08',
+      },
+    ];
+
+    for (const inv of invoicesData) {
+      const existing = await db.query.invoices.findFirst({
+        where: eq(invoices.number, inv.number),
+      });
+
+      if (!existing) {
+        console.log(`Creating invoice ${inv.number}...`);
+        await db.insert(invoices).values(inv);
+      } else {
+        console.log(`Invoice ${inv.number} already exists.`);
+      }
+    }
+
+    // 4. Update Next Invoice Number in Settings
+    // Find the highest invoice number (assuming format INV-XXXX)
+    let maxInvoiceNum = 0;
+
+    // Check all existing invoices to find the max number
+    const allInvoices = await db.query.invoices.findMany();
+    for (const inv of allInvoices) {
+      if (inv.number.startsWith('INV-')) {
+        const numPart = parseInt(inv.number.replace('INV-', ''), 10);
+        if (!isNaN(numPart) && numPart > maxInvoiceNum) {
+          maxInvoiceNum = numPart;
+        }
+      }
+    }
+
+    // Set next invoice number to max + 1
+    const nextInvoiceNum = maxInvoiceNum + 1;
+    console.log(`Updating settings: Next Invoice Number set to ${nextInvoiceNum}`);
+
+    await db.update(settings)
+      .set({ nextInvoiceNumber: nextInvoiceNum })
+      .where(eq(settings.id, 1));
+
+    console.log('✅ Test data seeded successfully!');
+    process.exit(0);
+
+  } catch (error) {
+    console.error('❌ Error Seeding Data:', error);
+    process.exit(1);
+  }
 }
 
 seedData();

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -15,6 +15,7 @@ import dashboardRoutes from './routes/dashboard.js';
 import reportsRoutes from './routes/reports.js';
 import importRoutes from './routes/import.js';
 import migrationsRoutes from './routes/migrations.js';
+import integrationRoutes from './routes/integration.js';
 
 import { errorHandler } from './middleware/errorHandler.js';
 import { createCorsMiddleware } from './middleware/cors.js';
@@ -101,6 +102,7 @@ export function createApp() {
   app.use('/api/export', reportsRoutes);
   app.use('/api/import', importRoutes);
   app.use('/api/migrations', migrationsRoutes);
+  app.use('/api/integration', integrationRoutes);
   app.use('/api/auth', authRoutes);
 
   // Lightweight health endpoint - only responds when database is initialized

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -97,6 +97,21 @@ export const invoices = sqliteTable('invoices', {
   statusDueDateIdx: index('invoices_status_due_date_idx').on(table.status, table.dueDate),
 }));
 
+
+// API keys table
+export const apiKeys = sqliteTable('api_keys', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  name: text('name').notNull().default('Default API Key'),
+  keyHash: text('key_hash').notNull().unique(),
+  keyPrefix: text('key_prefix').notNull(),
+  keyLastFour: text('key_last_four').notNull(),
+  createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
+  lastUsedAt: text('last_used_at'),
+  revokedAt: text('revoked_at'),
+}, (table) => ({
+  activeIdx: index('api_keys_active_idx').on(table.revokedAt),
+}));
+
 // Invoice line items table
 export const invoiceLineItems = sqliteTable('invoice_line_items', {
   id: integer('id').primaryKey({ autoIncrement: true }),
@@ -135,3 +150,7 @@ export type NewInvoice = typeof invoices.$inferInsert;
 
 export type InvoiceLineItem = typeof invoiceLineItems.$inferSelect;
 export type NewInvoiceLineItem = typeof invoiceLineItems.$inferInsert;
+
+
+export type ApiKey = typeof apiKeys.$inferSelect;
+export type NewApiKey = typeof apiKeys.$inferInsert;

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -101,16 +101,13 @@ export const invoices = sqliteTable('invoices', {
 // API keys table
 export const apiKeys = sqliteTable('api_keys', {
   id: integer('id').primaryKey({ autoIncrement: true }),
-  name: text('name').notNull().default('Default API Key'),
+  name: text('name').notNull().unique(),
   keyHash: text('key_hash').notNull().unique(),
   keyPrefix: text('key_prefix').notNull(),
   keyLastFour: text('key_last_four').notNull(),
   createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
   lastUsedAt: text('last_used_at'),
-  revokedAt: text('revoked_at'),
-}, (table) => ({
-  activeIdx: index('api_keys_active_idx').on(table.revokedAt),
-}));
+});
 
 // Invoice line items table
 export const invoiceLineItems = sqliteTable('invoice_line_items', {

--- a/backend/src/middleware/apiKeyAuth.ts
+++ b/backend/src/middleware/apiKeyAuth.ts
@@ -1,5 +1,5 @@
 import type { NextFunction, Request, Response } from 'express';
-import { and, eq, isNull } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { createHash, randomUUID } from 'node:crypto';
 import { db } from '../db/index.js';
 import { apiKeys } from '../db/schema.js';
@@ -41,10 +41,7 @@ export async function requireApiKey(req: Request, res: Response, next: NextFunct
       .select()
       .from(apiKeys)
       .where(
-        and(
-          eq(apiKeys.keyHash, hashedInput),
-          isNull(apiKeys.revokedAt)
-        )
+        eq(apiKeys.keyHash, hashedInput)
       )
       .limit(1);
 

--- a/backend/src/middleware/apiKeyAuth.ts
+++ b/backend/src/middleware/apiKeyAuth.ts
@@ -1,0 +1,84 @@
+import type { NextFunction, Request, Response } from 'express';
+import { and, eq, isNull } from 'drizzle-orm';
+import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
+import { db } from '../db/index.js';
+import { apiKeys } from '../db/schema.js';
+
+function hashApiKey(apiKey: string) {
+  return createHash('sha256').update(apiKey).digest('hex');
+}
+
+function extractApiKey(req: Request) {
+  const headerKey = req.header('x-api-key');
+  if (headerKey) {
+    return headerKey.trim();
+  }
+
+  const authHeader = req.header('authorization');
+  if (!authHeader) {
+    return null;
+  }
+
+  const [scheme, token] = authHeader.split(' ');
+  if (scheme?.toLowerCase() !== 'bearer' || !token) {
+    return null;
+  }
+
+  return token.trim();
+}
+
+export async function requireApiKey(req: Request, res: Response, next: NextFunction) {
+  try {
+    const apiKey = extractApiKey(req);
+
+    if (!apiKey) {
+      return res.status(401).json({ error: 'Missing API key' });
+    }
+
+    const hashedInput = hashApiKey(apiKey);
+
+    const [record] = await db
+      .select()
+      .from(apiKeys)
+      .where(
+        and(
+          eq(apiKeys.keyHash, hashedInput),
+          isNull(apiKeys.revokedAt)
+        )
+      )
+      .limit(1);
+
+    if (!record) {
+      return res.status(401).json({ error: 'Invalid API key' });
+    }
+
+    const providedBuffer = Buffer.from(hashedInput, 'utf8');
+    const storedBuffer = Buffer.from(record.keyHash, 'utf8');
+
+    if (
+      providedBuffer.length !== storedBuffer.length
+      || !timingSafeEqual(providedBuffer, storedBuffer)
+    ) {
+      return res.status(401).json({ error: 'Invalid API key' });
+    }
+
+    await db
+      .update(apiKeys)
+      .set({ lastUsedAt: new Date().toISOString() })
+      .where(eq(apiKeys.id, record.id));
+
+    return next();
+  } catch (error) {
+    return next(error);
+  }
+}
+
+export function createApiKey() {
+  const raw = `tsia_${randomUUID().replace(/-/g, '')}${randomUUID().replace(/-/g, '')}`;
+  return {
+    raw,
+    keyHash: hashApiKey(raw),
+    keyPrefix: raw.slice(0, 8),
+    keyLastFour: raw.slice(-4),
+  };
+}

--- a/backend/src/middleware/apiKeyAuth.ts
+++ b/backend/src/middleware/apiKeyAuth.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
 import { and, eq, isNull } from 'drizzle-orm';
-import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { db } from '../db/index.js';
 import { apiKeys } from '../db/schema.js';
 
@@ -49,16 +49,6 @@ export async function requireApiKey(req: Request, res: Response, next: NextFunct
       .limit(1);
 
     if (!record) {
-      return res.status(401).json({ error: 'Invalid API key' });
-    }
-
-    const providedBuffer = Buffer.from(hashedInput, 'utf8');
-    const storedBuffer = Buffer.from(record.keyHash, 'utf8');
-
-    if (
-      providedBuffer.length !== storedBuffer.length
-      || !timingSafeEqual(providedBuffer, storedBuffer)
-    ) {
       return res.status(401).json({ error: 'Invalid API key' });
     }
 

--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -1,89 +1,21 @@
 import { Router } from 'express';
 import { db } from '../db/index.js';
 import {
-  timeEntries,
-  expenses,
   invoices,
-  projects,
-  clients
+  timeEntries,
 } from '../db/schema.js';
-import { eq, and, sql } from 'drizzle-orm';
+import { and, sql } from 'drizzle-orm';
 import { requireAuth } from '../middleware/auth.js';
-import { calculateDaysOverdue, getLastNMonths } from '../utils/time.js';
+import { getLastNMonths } from '../utils/time.js';
+import { getDashboardSummaryData } from '../services/dashboardData.js';
 
 const router = Router();
 
 // GET /api/dashboard/summary
 router.get('/summary', requireAuth, async (req, res, next) => {
   try {
-    // Uninvoiced hours by project
-    const uninvoicedHoursRaw = await db
-      .select({
-        projectId: timeEntries.projectId,
-        projectName: projects.name,
-        clientId: clients.id,
-        clientName: clients.name,
-        totalHours: sql<number>`SUM(${timeEntries.totalHours})`,
-        hourlyRate: projects.hourlyRate,
-        totalAmount: sql<number>`SUM(${timeEntries.totalHours}) * ${projects.hourlyRate}`,
-      })
-      .from(timeEntries)
-      .innerJoin(projects, eq(timeEntries.projectId, projects.id))
-      .innerJoin(clients, eq(projects.clientId, clients.id))
-      .where(
-        and(
-          eq(timeEntries.isInvoiced, false),
-          sql`${timeEntries.endAt} IS NOT NULL`
-        )
-      )
-      .groupBy(timeEntries.projectId, projects.name, clients.id, clients.name, projects.hourlyRate);
-
-    // Uninvoiced expenses by project
-    const uninvoicedExpensesRaw = await db
-      .select({
-        projectId: expenses.projectId,
-        projectName: projects.name,
-        clientId: clients.id,
-        clientName: clients.name,
-        totalAmount: sql<number>`SUM(${expenses.amount})`,
-      })
-      .from(expenses)
-      .innerJoin(projects, eq(expenses.projectId, projects.id))
-      .innerJoin(clients, eq(projects.clientId, clients.id))
-      .where(
-        and(
-          eq(expenses.isInvoiced, false),
-          eq(expenses.isBillable, true)
-        )
-      )
-      .groupBy(expenses.projectId, projects.name, clients.id, clients.name);
-
-    // Outstanding invoices
-    const outstandingInvoicesRaw = await db
-      .select({
-        invoice: invoices,
-        clientName: clients.name,
-      })
-      .from(invoices)
-      .innerJoin(clients, eq(invoices.clientId, clients.id))
-      .where(eq(invoices.status, 'Sent'))
-      .orderBy(invoices.dueDate);
-
-    const outstandingInvoices = outstandingInvoicesRaw.map(({ invoice, clientName }) => ({
-      id: invoice.id,
-      number: invoice.number,
-      dateInvoiced: invoice.dateInvoiced,
-      dueDate: invoice.dueDate,
-      clientName,
-      total: invoice.total,
-      daysOverdue: calculateDaysOverdue(invoice.dueDate),
-    }));
-
-    res.json({
-      uninvoicedHoursByProject: uninvoicedHoursRaw,
-      uninvoicedExpensesByProject: uninvoicedExpensesRaw,
-      outstandingInvoices,
-    });
+    const summary = await getDashboardSummaryData();
+    res.json(summary);
   } catch (error) {
     next(error);
   }

--- a/backend/src/routes/integration.ts
+++ b/backend/src/routes/integration.ts
@@ -1,0 +1,48 @@
+import { Router } from 'express';
+import { requireApiKey } from '../middleware/apiKeyAuth.js';
+import {
+  getOutstandingInvoices,
+  getUninvoicedExpensesByProject,
+  getUninvoicedHoursByProject,
+} from '../services/dashboardData.js';
+
+const router = Router();
+
+router.use(requireApiKey);
+
+// GET /api/integration/fetchOutstandingInvoices
+router.get('/fetchOutstandingInvoices', async (_req, res, next) => {
+  try {
+    const outstandingInvoices = await getOutstandingInvoices();
+    return res.json({
+      data: outstandingInvoices,
+      count: outstandingInvoices.length,
+    });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+// GET /api/integration/fetchUninvoicedItems
+router.get('/fetchUninvoicedItems', async (_req, res, next) => {
+  try {
+    const [uninvoicedHours, uninvoicedExpenses] = await Promise.all([
+      getUninvoicedHoursByProject(),
+      getUninvoicedExpensesByProject(),
+    ]);
+
+    return res.json({
+      hours: uninvoicedHours,
+      expenses: uninvoicedExpenses,
+      totals: {
+        totalHours: uninvoicedHours.reduce((sum, row) => sum + row.totalHours, 0),
+        totalHoursAmount: uninvoicedHours.reduce((sum, row) => sum + row.totalAmount, 0),
+        totalExpensesAmount: uninvoicedExpenses.reduce((sum, row) => sum + row.totalAmount, 0),
+      },
+    });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+export default router;

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
+import { desc, eq, isNull } from 'drizzle-orm';
 import { db } from '../db/index.js';
-import { settings } from '../db/schema.js';
-import { eq } from 'drizzle-orm';
-import { updateSettingsSchema } from '../types/validation.js';
+import { apiKeys, settings } from '../db/schema.js';
 import { requireAuth } from '../middleware/auth.js';
+import { createApiKey } from '../middleware/apiKeyAuth.js';
+import { updateSettingsSchema } from '../types/validation.js';
 
 const router = Router();
 
@@ -20,15 +21,14 @@ router.get('/', requireAuth, async (req, res, next) => {
       return res.status(404).json({ error: 'Settings not found' });
     }
 
-    // Add timezone from env
     const response = {
       ...settingsData,
       timezone: process.env.TZ || 'Pacific/Auckland',
     };
 
-    res.json(response);
+    return res.json(response);
   } catch (error) {
-    next(error);
+    return next(error);
   }
 });
 
@@ -46,9 +46,103 @@ router.put('/', requireAuth, async (req, res, next) => {
       .where(eq(settings.id, 1))
       .returning();
 
-    res.json(updated);
+    return res.json(updated);
   } catch (error) {
-    next(error);
+    return next(error);
+  }
+});
+
+// GET /api/settings/api-keys
+router.get('/api-keys', requireAuth, async (_req, res, next) => {
+  try {
+    const records = await db
+      .select({
+        id: apiKeys.id,
+        name: apiKeys.name,
+        keyPrefix: apiKeys.keyPrefix,
+        keyLastFour: apiKeys.keyLastFour,
+        createdAt: apiKeys.createdAt,
+        lastUsedAt: apiKeys.lastUsedAt,
+        revokedAt: apiKeys.revokedAt,
+      })
+      .from(apiKeys)
+      .orderBy(desc(apiKeys.createdAt));
+
+    return res.json({
+      keys: records,
+      hasActiveKey: records.some((key) => !key.revokedAt),
+    });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+// POST /api/settings/api-keys/generate
+router.post('/api-keys/generate', requireAuth, async (req, res, next) => {
+  try {
+    const generated = createApiKey();
+
+    await db.transaction(async (tx) => {
+      await tx
+        .update(apiKeys)
+        .set({ revokedAt: new Date().toISOString() })
+        .where(isNull(apiKeys.revokedAt));
+
+      await tx.insert(apiKeys).values({
+        name: 'Default API Key',
+        keyHash: generated.keyHash,
+        keyPrefix: generated.keyPrefix,
+        keyLastFour: generated.keyLastFour,
+        createdAt: new Date().toISOString(),
+      });
+    });
+
+    return res.status(201).json({
+      apiKey: generated.raw,
+      keyPrefix: generated.keyPrefix,
+      keyLastFour: generated.keyLastFour,
+      createdAt: new Date().toISOString(),
+      warning: 'Store this key securely. You will not be able to view it again.',
+    });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+
+
+// DELETE /api/settings/api-keys/:id
+router.delete('/api-keys/:id', requireAuth, async (req, res, next) => {
+  try {
+    const keyIdParam = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+    const keyId = Number.parseInt(keyIdParam, 10);
+
+    if (!Number.isInteger(keyId) || keyId <= 0) {
+      return res.status(400).json({ error: 'Invalid API key id' });
+    }
+
+    const [existing] = await db
+      .select({ id: apiKeys.id, revokedAt: apiKeys.revokedAt })
+      .from(apiKeys)
+      .where(eq(apiKeys.id, keyId))
+      .limit(1);
+
+    if (!existing) {
+      return res.status(404).json({ error: 'API key not found' });
+    }
+
+    if (existing.revokedAt) {
+      return res.status(400).json({ error: 'API key already revoked' });
+    }
+
+    await db
+      .update(apiKeys)
+      .set({ revokedAt: new Date().toISOString() })
+      .where(eq(apiKeys.id, keyId));
+
+    return res.json({ success: true });
+  } catch (error) {
+    return next(error);
   }
 });
 

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -1,10 +1,10 @@
 import { Router } from 'express';
-import { desc, eq, isNull } from 'drizzle-orm';
+import { desc, eq } from 'drizzle-orm';
 import { db } from '../db/index.js';
 import { apiKeys, settings } from '../db/schema.js';
 import { requireAuth } from '../middleware/auth.js';
 import { createApiKey } from '../middleware/apiKeyAuth.js';
-import { updateSettingsSchema } from '../types/validation.js';
+import { updateSettingsSchema, generateApiKeySchema } from '../types/validation.js';
 
 const router = Router();
 
@@ -63,14 +63,12 @@ router.get('/api-keys', requireAuth, async (_req, res, next) => {
         keyLastFour: apiKeys.keyLastFour,
         createdAt: apiKeys.createdAt,
         lastUsedAt: apiKeys.lastUsedAt,
-        revokedAt: apiKeys.revokedAt,
       })
       .from(apiKeys)
       .orderBy(desc(apiKeys.createdAt));
 
     return res.json({
       keys: records,
-      hasActiveKey: records.some((key) => !key.revokedAt),
     });
   } catch (error) {
     return next(error);
@@ -80,25 +78,20 @@ router.get('/api-keys', requireAuth, async (_req, res, next) => {
 // POST /api/settings/api-keys/generate
 router.post('/api-keys/generate', requireAuth, async (req, res, next) => {
   try {
+    const { name } = generateApiKeySchema.parse(req.body);
     const generated = createApiKey();
 
-    await db.transaction(async (tx) => {
-      await tx
-        .update(apiKeys)
-        .set({ revokedAt: new Date().toISOString() })
-        .where(isNull(apiKeys.revokedAt));
-
-      await tx.insert(apiKeys).values({
-        name: 'Default API Key',
-        keyHash: generated.keyHash,
-        keyPrefix: generated.keyPrefix,
-        keyLastFour: generated.keyLastFour,
-        createdAt: new Date().toISOString(),
-      });
+    await db.insert(apiKeys).values({
+      name,
+      keyHash: generated.keyHash,
+      keyPrefix: generated.keyPrefix,
+      keyLastFour: generated.keyLastFour,
+      createdAt: new Date().toISOString(),
     });
 
     return res.status(201).json({
       apiKey: generated.raw,
+      name,
       keyPrefix: generated.keyPrefix,
       keyLastFour: generated.keyLastFour,
       createdAt: new Date().toISOString(),
@@ -122,7 +115,7 @@ router.delete('/api-keys/:id', requireAuth, async (req, res, next) => {
     }
 
     const [existing] = await db
-      .select({ id: apiKeys.id, revokedAt: apiKeys.revokedAt })
+      .select({ id: apiKeys.id })
       .from(apiKeys)
       .where(eq(apiKeys.id, keyId))
       .limit(1);
@@ -131,13 +124,8 @@ router.delete('/api-keys/:id', requireAuth, async (req, res, next) => {
       return res.status(404).json({ error: 'API key not found' });
     }
 
-    if (existing.revokedAt) {
-      return res.status(400).json({ error: 'API key already revoked' });
-    }
-
     await db
-      .update(apiKeys)
-      .set({ revokedAt: new Date().toISOString() })
+      .delete(apiKeys)
       .where(eq(apiKeys.id, keyId));
 
     return res.json({ success: true });

--- a/backend/src/services/dashboardData.ts
+++ b/backend/src/services/dashboardData.ts
@@ -1,0 +1,84 @@
+import { and, eq, sql } from 'drizzle-orm';
+import { db } from '../db/index.js';
+import { clients, expenses, invoices, projects, timeEntries } from '../db/schema.js';
+import { calculateDaysOverdue } from '../utils/time.js';
+
+export async function getUninvoicedHoursByProject() {
+  return db
+    .select({
+      projectId: timeEntries.projectId,
+      projectName: projects.name,
+      clientId: clients.id,
+      clientName: clients.name,
+      totalHours: sql<number>`SUM(${timeEntries.totalHours})`,
+      hourlyRate: projects.hourlyRate,
+      totalAmount: sql<number>`SUM(${timeEntries.totalHours}) * ${projects.hourlyRate}`,
+    })
+    .from(timeEntries)
+    .innerJoin(projects, eq(timeEntries.projectId, projects.id))
+    .innerJoin(clients, eq(projects.clientId, clients.id))
+    .where(
+      and(
+        eq(timeEntries.isInvoiced, false),
+        sql`${timeEntries.endAt} IS NOT NULL`
+      )
+    )
+    .groupBy(timeEntries.projectId, projects.name, clients.id, clients.name, projects.hourlyRate);
+}
+
+export async function getUninvoicedExpensesByProject() {
+  return db
+    .select({
+      projectId: expenses.projectId,
+      projectName: projects.name,
+      clientId: clients.id,
+      clientName: clients.name,
+      totalAmount: sql<number>`SUM(${expenses.amount})`,
+    })
+    .from(expenses)
+    .innerJoin(projects, eq(expenses.projectId, projects.id))
+    .innerJoin(clients, eq(projects.clientId, clients.id))
+    .where(
+      and(
+        eq(expenses.isInvoiced, false),
+        eq(expenses.isBillable, true)
+      )
+    )
+    .groupBy(expenses.projectId, projects.name, clients.id, clients.name);
+}
+
+export async function getOutstandingInvoices() {
+  const outstandingInvoicesRaw = await db
+    .select({
+      invoice: invoices,
+      clientName: clients.name,
+    })
+    .from(invoices)
+    .innerJoin(clients, eq(invoices.clientId, clients.id))
+    .where(eq(invoices.status, 'Sent'))
+    .orderBy(invoices.dueDate);
+
+  return outstandingInvoicesRaw.map(({ invoice, clientName }) => ({
+    id: invoice.id,
+    number: invoice.number,
+    dateInvoiced: invoice.dateInvoiced,
+    dueDate: invoice.dueDate,
+    clientName,
+    total: invoice.total,
+    daysOverdue: calculateDaysOverdue(invoice.dueDate),
+  }));
+}
+
+export async function getDashboardSummaryData() {
+  const [uninvoicedHoursByProject, uninvoicedExpensesByProject, outstandingInvoices] = await Promise.all([
+    getUninvoicedHoursByProject(),
+    getUninvoicedExpensesByProject(),
+    getOutstandingInvoices(),
+  ]);
+
+  return {
+    uninvoicedHoursByProject,
+    uninvoicedExpensesByProject,
+    outstandingInvoices,
+  };
+}

--- a/backend/src/tests/integration-api.test.ts
+++ b/backend/src/tests/integration-api.test.ts
@@ -1,0 +1,51 @@
+import { beforeAll, describe, expect, test } from 'bun:test';
+import request from 'supertest';
+import { createApp } from '../app.js';
+import { createAuthenticatedAgent, ensureTestSettings } from './helpers.js';
+
+describe('Integration API Routes', () => {
+  let app: any;
+  let agent: ReturnType<typeof request.agent>;
+  let apiKey = '';
+
+  beforeAll(async () => {
+    ensureTestSettings();
+    app = createApp();
+    agent = request.agent(app);
+    await createAuthenticatedAgent(agent);
+
+    const keyResponse = await agent.post('/api/settings/api-keys/generate').send();
+    apiKey = keyResponse.body.apiKey;
+  });
+
+  test('requires API key for outstanding invoices endpoint', async () => {
+    const res = await request(app).get('/api/integration/fetchOutstandingInvoices');
+    expect(res.status).toBe(401);
+  });
+
+  test('returns outstanding invoices aligned with dashboard summary', async () => {
+    const dashboardRes = await agent.get('/api/dashboard/summary');
+    expect(dashboardRes.status).toBe(200);
+
+    const integrationRes = await request(app)
+      .get('/api/integration/fetchOutstandingInvoices')
+      .set('x-api-key', apiKey);
+
+    expect(integrationRes.status).toBe(200);
+    expect(integrationRes.body.data).toEqual(dashboardRes.body.outstandingInvoices);
+    expect(integrationRes.body.count).toBe(dashboardRes.body.outstandingInvoices.length);
+  });
+
+  test('returns uninvoiced items aligned with dashboard summary', async () => {
+    const dashboardRes = await agent.get('/api/dashboard/summary');
+    expect(dashboardRes.status).toBe(200);
+
+    const integrationRes = await request(app)
+      .get('/api/integration/fetchUninvoicedItems')
+      .set('authorization', `Bearer ${apiKey}`);
+
+    expect(integrationRes.status).toBe(200);
+    expect(integrationRes.body.hours).toEqual(dashboardRes.body.uninvoicedHoursByProject);
+    expect(integrationRes.body.expenses).toEqual(dashboardRes.body.uninvoicedExpensesByProject);
+  });
+});

--- a/backend/src/tests/integration-api.test.ts
+++ b/backend/src/tests/integration-api.test.ts
@@ -14,7 +14,7 @@ describe('Integration API Routes', () => {
     agent = request.agent(app);
     await createAuthenticatedAgent(agent);
 
-    const keyResponse = await agent.post('/api/settings/api-keys/generate').send();
+    const keyResponse = await agent.post('/api/settings/api-keys/generate').send({ name: 'Integration Test Key' });
     apiKey = keyResponse.body.apiKey;
   });
 

--- a/backend/src/tests/settings.test.ts
+++ b/backend/src/tests/settings.test.ts
@@ -182,37 +182,78 @@ describe("Settings Routes", () => {
   });
 
   describe("API Key Management", () => {
-    test("should generate and list API key", async () => {
-      const generateRes = await agent.post("/api/settings/api-keys/generate");
+    test("should generate and list API key with name", async () => {
+      const generateRes = await agent
+        .post("/api/settings/api-keys/generate")
+        .send({ name: "Test Key 1" });
 
       expect(generateRes.status).toBe(201);
       expect(generateRes.body.apiKey).toMatch(/^tsia_/);
+      expect(generateRes.body.name).toBe("Test Key 1");
       expect(generateRes.body.warning).toBeDefined();
 
       const listRes = await agent.get("/api/settings/api-keys");
       expect(listRes.status).toBe(200);
-      expect(listRes.body.hasActiveKey).toBe(true);
       expect(listRes.body.keys.length).toBeGreaterThan(0);
-      expect(listRes.body.keys[0].keyPrefix).toBeDefined();
-      expect(listRes.body.keys[0].keyLastFour).toBeDefined();
-      expect(listRes.body.keys[0].revokedAt).toBeNull();
+
+      const createdKey = listRes.body.keys.find((key: any) => key.name === "Test Key 1");
+      expect(createdKey).toBeDefined();
+      expect(createdKey.keyPrefix).toBeDefined();
+      expect(createdKey.keyLastFour).toBeDefined();
     });
 
-    test("should delete active API key", async () => {
-      const generateRes = await agent.post("/api/settings/api-keys/generate");
+    test("should require name when generating API key", async () => {
+      const res = await agent.post("/api/settings/api-keys/generate").send({});
+      expect(res.status).toBe(400);
+    });
+
+    test("should reject duplicate key names", async () => {
+      await agent
+        .post("/api/settings/api-keys/generate")
+        .send({ name: "Duplicate Name Test" });
+
+      const duplicateRes = await agent
+        .post("/api/settings/api-keys/generate")
+        .send({ name: "Duplicate Name Test" });
+
+      expect(duplicateRes.status).toBe(409);
+    });
+
+    test("should support multiple active API keys", async () => {
+      const key1Res = await agent
+        .post("/api/settings/api-keys/generate")
+        .send({ name: "Multi Key A" });
+      expect(key1Res.status).toBe(201);
+
+      const key2Res = await agent
+        .post("/api/settings/api-keys/generate")
+        .send({ name: "Multi Key B" });
+      expect(key2Res.status).toBe(201);
+
+      const listRes = await agent.get("/api/settings/api-keys");
+      const keyA = listRes.body.keys.find((k: any) => k.name === "Multi Key A");
+      const keyB = listRes.body.keys.find((k: any) => k.name === "Multi Key B");
+      expect(keyA).toBeDefined();
+      expect(keyB).toBeDefined();
+    });
+
+    test("should delete API key from database", async () => {
+      const generateRes = await agent
+        .post("/api/settings/api-keys/generate")
+        .send({ name: "Delete Me Key" });
       expect(generateRes.status).toBe(201);
 
       const beforeDelete = await agent.get("/api/settings/api-keys");
-      const activeKey = beforeDelete.body.keys.find((key: any) => !key.revokedAt);
-      expect(activeKey).toBeDefined();
+      const keyToDelete = beforeDelete.body.keys.find((key: any) => key.name === "Delete Me Key");
+      expect(keyToDelete).toBeDefined();
 
-      const deleteRes = await agent.delete(`/api/settings/api-keys/${activeKey.id}`);
+      const deleteRes = await agent.delete(`/api/settings/api-keys/${keyToDelete.id}`);
       expect(deleteRes.status).toBe(200);
       expect(deleteRes.body.success).toBe(true);
 
       const afterDelete = await agent.get("/api/settings/api-keys");
-      expect(afterDelete.status).toBe(200);
-      expect(afterDelete.body.hasActiveKey).toBe(false);
+      const deletedKey = afterDelete.body.keys.find((key: any) => key.name === "Delete Me Key");
+      expect(deletedKey).toBeUndefined();
     });
 
     test("should require authentication for API key routes", async () => {
@@ -220,7 +261,9 @@ describe("Settings Routes", () => {
       const listRes = await freshAgent.get("/api/settings/api-keys");
       expectUnauthorized(listRes);
 
-      const generateRes = await freshAgent.post("/api/settings/api-keys/generate");
+      const generateRes = await freshAgent
+        .post("/api/settings/api-keys/generate")
+        .send({ name: "Unauth Key" });
       expectUnauthorized(generateRes);
 
       const deleteRes = await freshAgent.delete("/api/settings/api-keys/1");

--- a/backend/src/tests/settings.test.ts
+++ b/backend/src/tests/settings.test.ts
@@ -180,4 +180,52 @@ describe("Settings Routes", () => {
       expectUnauthorized(res);
     });
   });
+
+  describe("API Key Management", () => {
+    test("should generate and list API key", async () => {
+      const generateRes = await agent.post("/api/settings/api-keys/generate");
+
+      expect(generateRes.status).toBe(201);
+      expect(generateRes.body.apiKey).toMatch(/^tsia_/);
+      expect(generateRes.body.warning).toBeDefined();
+
+      const listRes = await agent.get("/api/settings/api-keys");
+      expect(listRes.status).toBe(200);
+      expect(listRes.body.hasActiveKey).toBe(true);
+      expect(listRes.body.keys.length).toBeGreaterThan(0);
+      expect(listRes.body.keys[0].keyPrefix).toBeDefined();
+      expect(listRes.body.keys[0].keyLastFour).toBeDefined();
+      expect(listRes.body.keys[0].revokedAt).toBeNull();
+    });
+
+    test("should delete active API key", async () => {
+      const generateRes = await agent.post("/api/settings/api-keys/generate");
+      expect(generateRes.status).toBe(201);
+
+      const beforeDelete = await agent.get("/api/settings/api-keys");
+      const activeKey = beforeDelete.body.keys.find((key: any) => !key.revokedAt);
+      expect(activeKey).toBeDefined();
+
+      const deleteRes = await agent.delete(`/api/settings/api-keys/${activeKey.id}`);
+      expect(deleteRes.status).toBe(200);
+      expect(deleteRes.body.success).toBe(true);
+
+      const afterDelete = await agent.get("/api/settings/api-keys");
+      expect(afterDelete.status).toBe(200);
+      expect(afterDelete.body.hasActiveKey).toBe(false);
+    });
+
+    test("should require authentication for API key routes", async () => {
+      const freshAgent = request.agent(app);
+      const listRes = await freshAgent.get("/api/settings/api-keys");
+      expectUnauthorized(listRes);
+
+      const generateRes = await freshAgent.post("/api/settings/api-keys/generate");
+      expectUnauthorized(generateRes);
+
+      const deleteRes = await freshAgent.delete("/api/settings/api-keys/1");
+      expectUnauthorized(deleteRes);
+    });
+  });
+
 });

--- a/backend/src/types/validation.ts
+++ b/backend/src/types/validation.ts
@@ -152,3 +152,10 @@ export type CreateInvoiceLineItemInput = z.infer<typeof createInvoiceLineItemSch
 export type UpdateInvoiceLineItemInput = z.infer<typeof updateInvoiceLineItemSchema>;
 export type ImportInvoiceRowInput = z.infer<typeof importInvoiceRowSchema>;
 export type ImportInvoicesInput = z.infer<typeof importInvoicesSchema>;
+
+// API key schemas
+export const generateApiKeySchema = z.object({
+  name: z.string().min(1, 'API key name is required').max(100, 'API key name must be 100 characters or less').trim(),
+});
+
+export type GenerateApiKeyInput = z.infer<typeof generateApiKeySchema>;

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "timesheet-invoice-app",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,19 +17,6 @@ import Reports from './pages/Reports';
 import Settings from './pages/Settings';
 import ApiDocs from './pages/ApiDocs';
 
-function ProtectedRoute({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated, loading } = useAuth();
-
-  if (loading) {
-    return <LoadingOverlay visible />;
-  }
-
-  if (!isAuthenticated) {
-    return <Navigate to="/login" replace />;
-  }
-
-  return <>{children}</>;
-}
 
 function AppRoutes() {
   const { isAuthenticated, loading } = useAuth();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import InvoiceDetail from './pages/InvoiceDetail';
 import ImportInvoices from './pages/ImportInvoices';
 import Reports from './pages/Reports';
 import Settings from './pages/Settings';
+import ApiDocs from './pages/ApiDocs';
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, loading } = useAuth();
@@ -61,6 +62,7 @@ function AppRoutes() {
           <Route path="/import/invoices" element={<ImportInvoices />} />
           <Route path="/reports" element={<Reports />} />
           <Route path="/settings" element={<Settings />} />
+          <Route path="/settings/api-docs" element={<ApiDocs />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </Layout>

--- a/frontend/src/components/TimerNotesModal.tsx
+++ b/frontend/src/components/TimerNotesModal.tsx
@@ -6,7 +6,7 @@ interface TimerNotesModalProps {
   opened: boolean;
   onClose: () => void;
   currentTimer: TimeEntry | null;
-  onSave: (note: string | undefined) => Promise<void>;
+  onSave: (note: string | undefined) => Promise<unknown>;
 }
 
 export default function TimerNotesModal({

--- a/frontend/src/contexts/TimerContext.tsx
+++ b/frontend/src/contexts/TimerContext.tsx
@@ -14,9 +14,9 @@ import {
 interface TimerContextType {
   currentTimer: TimeEntry | null;
   isLoading: boolean;
-  startTimer: (projectId: number) => Promise<void>;
-  stopTimer: (projectId: number) => Promise<void>;
-  updateTimerNotes: (note: string | undefined) => Promise<void>;
+  startTimer: (projectId: number) => Promise<TimeEntry>;
+  stopTimer: (projectId: number) => Promise<TimeEntry>;
+  updateTimerNotes: (note: string | undefined) => Promise<TimeEntry>;
   refetch: () => void;
 }
 

--- a/frontend/src/pages/ApiDocs.tsx
+++ b/frontend/src/pages/ApiDocs.tsx
@@ -1,0 +1,111 @@
+import { Button, Card, Code, Container, Group, List, Stack, Text, Title } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { IconCopy } from '@tabler/icons-react';
+
+const apiDocsMarkdown = `# Timesheet Invoice App - Integration API\n\nBase URL: \`/api/integration\`\nAuthentication: Include generated API key via \`x-api-key\` header (preferred) or \`Authorization: Bearer <API_KEY>\`.\n\n## Endpoints\n\n### GET /api/integration/fetchOutstandingInvoices\nReturns invoices with status \`Sent\` from Dashboard Outstanding Invoices.\n\nResponse shape:\n\n\`\`\`json
+{
+  "data": [
+    {
+      "id": 1,
+      "number": "INV-1001",
+      "dateInvoiced": "2026-01-10",
+      "dueDate": "2026-02-10",
+      "clientName": "Acme Ltd",
+      "total": 1200,
+      "daysOverdue": 0
+    }
+  ],
+  "count": 1
+}
+\`\`\`\n\n### GET /api/integration/fetchUninvoicedItems\nReturns uninvoiced hours and billable expenses from Dashboard cards.\n\nResponse shape:\n\n\`\`\`json
+{
+  "hours": [
+    {
+      "projectId": 1,
+      "projectName": "Website",
+      "clientId": 2,
+      "clientName": "Acme Ltd",
+      "totalHours": 12.5,
+      "hourlyRate": 120,
+      "totalAmount": 1500
+    }
+  ],
+  "expenses": [
+    {
+      "projectId": 1,
+      "projectName": "Website",
+      "clientId": 2,
+      "clientName": "Acme Ltd",
+      "totalAmount": 230
+    }
+  ],
+  "totals": {
+    "totalHours": 12.5,
+    "totalHoursAmount": 1500,
+    "totalExpensesAmount": 230
+  }
+}
+\`\`\`\n\n## Example cURL\n\`\`\`bash
+curl -H "x-api-key: YOUR_API_KEY" \\
+  http://localhost:8080/api/integration/fetchOutstandingInvoices
+\`\`\`
+`;
+
+export default function ApiDocs() {
+  const handleCopyMarkdown = async () => {
+    try {
+      await navigator.clipboard.writeText(apiDocsMarkdown);
+      notifications.show({
+        title: 'Copied',
+        message: 'API docs markdown copied to clipboard',
+        color: 'green',
+      });
+    } catch {
+      notifications.show({
+        title: 'Copy failed',
+        message: 'Unable to copy markdown from this browser',
+        color: 'red',
+      });
+    }
+  };
+
+  return (
+    <Container size="md">
+      <Stack gap="lg">
+        <Group justify="space-between" align="center">
+          <Title order={1}>Integration API Docs</Title>
+          <Button leftSection={<IconCopy size={16} />} onClick={handleCopyMarkdown}>
+            Copy Markdown
+          </Button>
+        </Group>
+
+        <Card shadow="sm" padding="lg">
+          <Stack gap="md">
+            <Text>
+              These endpoints are authenticated with your generated API key and provide the same data as the
+              dashboard widgets.
+            </Text>
+            <List>
+              <List.Item>
+                <Code>GET /api/integration/fetchOutstandingInvoices</Code>
+              </List.Item>
+              <List.Item>
+                <Code>GET /api/integration/fetchUninvoicedItems</Code>
+              </List.Item>
+            </List>
+            <Text size="sm" c="dimmed">
+              Send your API key using <Code>x-api-key</Code> header, or Bearer token format in Authorization.
+            </Text>
+          </Stack>
+        </Card>
+
+        <Card shadow="sm" padding="lg">
+          <Text fw={600} mb="xs">
+            Markdown Source
+          </Text>
+          <Code block>{apiDocsMarkdown}</Code>
+        </Card>
+      </Stack>
+    </Container>
+  );
+}

--- a/frontend/src/pages/ClientDetail.tsx
+++ b/frontend/src/pages/ClientDetail.tsx
@@ -312,14 +312,14 @@ export default function ClientDetail() {
               label="Invoice Date"
               placeholder="Select date"
               value={invoiceForm.values.dateInvoiced}
-              onChange={(val) => invoiceForm.setFieldValue('dateInvoiced', val || new Date())}
+              onChange={(val) => invoiceForm.setFieldValue('dateInvoiced', val ? (typeof val === 'string' ? new Date(val) : val) : new Date())}
               required
             />
             <DatePickerInput
               label="Include Items Up To"
               placeholder="Select date"
               value={invoiceForm.values.upToDate}
-              onChange={(val) => invoiceForm.setFieldValue('upToDate', val || new Date())}
+              onChange={(val) => invoiceForm.setFieldValue('upToDate', val ? (typeof val === 'string' ? new Date(val) : val) : new Date())}
               required
             />
 

--- a/frontend/src/pages/Invoices.tsx
+++ b/frontend/src/pages/Invoices.tsx
@@ -25,8 +25,8 @@ export default function Invoices() {
   const [statusFilter, setStatusFilter] = useState<string>('Sent');
   const [clientFilter, setClientFilter] = useState<string>('');
   const [projectFilter, setProjectFilter] = useState<string>('');
-  const [fromDate, setFromDate] = useState<Date | null>(null);
-  const [toDate, setToDate] = useState<Date | null>(null);
+  const [fromDate, setFromDate] = useState<string | null>(null);
+  const [toDate, setToDate] = useState<string | null>(null);
   const [filtersExpanded, setFiltersExpanded] = useState(false);
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(25);
@@ -38,8 +38,8 @@ export default function Invoices() {
         status: statusFilter || undefined,
         clientId: clientFilter ? parseInt(clientFilter) : undefined,
         projectId: projectFilter ? parseInt(projectFilter) : undefined,
-        from: fromDate ? DateTime.fromJSDate(fromDate).toISODate() : undefined,
-        to: toDate ? DateTime.fromJSDate(toDate).toISODate() : undefined,
+        from: fromDate ? DateTime.fromISO(fromDate).toISODate() : undefined,
+        to: toDate ? DateTime.fromISO(toDate).toISODate() : undefined,
         page,
         pageSize,
       },
@@ -49,8 +49,8 @@ export default function Invoices() {
         status: statusFilter || undefined,
         clientId: clientFilter ? parseInt(clientFilter) : undefined,
         projectId: projectFilter ? parseInt(projectFilter) : undefined,
-        from: fromDate ? DateTime.fromJSDate(fromDate).toISODate() || undefined : undefined,
-        to: toDate ? DateTime.fromJSDate(toDate).toISODate() || undefined : undefined,
+        from: fromDate ? (DateTime.fromISO(fromDate).toISODate() || undefined) : undefined,
+        to: toDate ? (DateTime.fromISO(toDate).toISODate() || undefined) : undefined,
         page,
         pageSize,
       }),

--- a/frontend/src/pages/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetail.tsx
@@ -84,7 +84,7 @@ export default function ProjectDetail() {
     queryFn: () => projectsApi.get(projectId),
   });
 
-  const { data: clientsResponse, isLoading: clientsLoading } = useQuery({
+  const { data: clientsResponse } = useQuery({
     queryKey: ['clients'],
     queryFn: () => clientsApi.list(),
   });

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -23,11 +23,10 @@ type ReportType = 'invoices' | 'income';
 
 export default function Reports() {
   const [reportType, setReportType] = useState<ReportType>('invoices');
-  const [fromDate, setFromDate] = useState<Date | null>(() => {
-    const fyStart = getFinancialYearStart();
-    return DateTime.fromISO(fyStart).toJSDate();
+  const [fromDate, setFromDate] = useState<string | null>(() => {
+    return getFinancialYearStart();
   });
-  const [toDate, setToDate] = useState<Date | null>(null);
+  const [toDate, setToDate] = useState<string | null>(null);
   const [validationError, setValidationError] = useState<string | null>(null);
 
   // Validate dates whenever they change
@@ -40,21 +39,17 @@ export default function Reports() {
   }, [fromDate, toDate]);
 
   // Convert dates to ISO strings for API calls and query keys
-  const fromDateISO = fromDate 
-    ? (fromDate instanceof Date 
-        ? DateTime.fromJSDate(fromDate).toISODate() 
-        : DateTime.fromISO(fromDate as string).toISODate())
+  const fromDateISO = fromDate
+    ? DateTime.fromISO(fromDate).toISODate()
     : null;
-  const toDateISO = toDate 
-    ? (toDate instanceof Date 
-        ? DateTime.fromJSDate(toDate).toISODate() 
-        : DateTime.fromISO(toDate as string).toISODate())
+  const toDateISO = toDate
+    ? DateTime.fromISO(toDate).toISODate()
     : null;
 
   const { data: invoicesData, refetch: refetchInvoices } = useQuery({
     queryKey: ['reports', 'invoices', fromDateISO, toDateISO],
     queryFn: () => reportsApi.getInvoices(
-      fromDateISO ?? undefined, 
+      fromDateISO ?? undefined,
       toDateISO ?? undefined
     ),
     enabled: reportType === 'invoices' && !validationError,
@@ -65,7 +60,7 @@ export default function Reports() {
   const { data: incomeData, refetch: refetchIncome } = useQuery({
     queryKey: ['reports', 'income', fromDateISO, toDateISO],
     queryFn: () => reportsApi.getIncome(
-      fromDateISO ?? undefined, 
+      fromDateISO ?? undefined,
       toDateISO ?? undefined
     ),
     enabled: reportType === 'income' && !validationError,
@@ -84,16 +79,15 @@ export default function Reports() {
   };
 
   const handleReset = () => {
-    const fyStart = getFinancialYearStart();
-    setFromDate(DateTime.fromISO(fyStart).toJSDate());
+    setFromDate(getFinancialYearStart());
     setToDate(null);
   };
 
   const handleExportCsv = async () => {
     try {
       await reportsApi.exportCsv(
-        'invoices', 
-        fromDateISO ?? undefined, 
+        'invoices',
+        fromDateISO ?? undefined,
         toDateISO ?? undefined
       );
     } catch (error) {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -19,7 +19,6 @@ import {
   Paper,
   Anchor,
   Table,
-  Badge,
   ActionIcon,
   Modal,
   Tabs,
@@ -37,6 +36,8 @@ import type { ApiKeySummary } from '../types';
 export default function Settings() {
   const queryClient = useQueryClient();
   const [newApiKey, setNewApiKey] = useState<string | null>(null);
+  const [newKeyName, setNewKeyName] = useState('');
+  const [newKeyNameError, setNewKeyNameError] = useState<string | null>(null);
   const [deleteModalOpened, { open: openDeleteModal, close: closeDeleteModal }] = useDisclosure(false);
   const [deletingApiKey, setDeletingApiKey] = useState<ApiKeySummary | null>(null);
 
@@ -92,19 +93,25 @@ export default function Settings() {
     mutationFn: settingsApi.generateApiKey,
     onSuccess: (data) => {
       setNewApiKey(data.apiKey);
+      setNewKeyName('');
+      setNewKeyNameError(null);
       queryClient.invalidateQueries({ queryKey: ['api-keys'] });
       notifications.show({
         title: 'API key generated',
-        message: 'Your previous active key was revoked. Save this new key now.',
+        message: `API key "${data.name}" created. Save this key now.`,
         color: 'green',
       });
     },
     onError: (error: Error) => {
-      notifications.show({
-        title: 'Error',
-        message: error.message,
-        color: 'red',
-      });
+      if (error.message.includes('UNIQUE constraint failed')) {
+        setNewKeyNameError('An API key with this name already exists');
+      } else {
+        notifications.show({
+          title: 'Error',
+          message: error.message,
+          color: 'red',
+        });
+      }
     },
   });
 
@@ -212,6 +219,16 @@ export default function Settings() {
 
   const apiKeys = apiKeyData?.keys || [];
 
+  const handleGenerateApiKey = () => {
+    const trimmedName = newKeyName.trim();
+    if (!trimmedName) {
+      setNewKeyNameError('API key name is required');
+      return;
+    }
+    setNewKeyNameError(null);
+    generateApiKeyMutation.mutate(trimmedName);
+  };
+
   return (
     <Container size="md">
       <Title order={1} mb="xl">
@@ -224,7 +241,7 @@ export default function Settings() {
             <Tabs.List>
               <Tabs.Tab value="companyInfo">Company Info</Tabs.Tab>
               <Tabs.Tab value="invoiceSettings">Invoice Settings</Tabs.Tab>
-              <Tabs.Tab value="apiKeys">API Key</Tabs.Tab>
+              <Tabs.Tab value="apiKeys">API Keys</Tabs.Tab>
             </Tabs.List>
 
             <Tabs.Panel value="companyInfo" pt="md">
@@ -352,23 +369,34 @@ export default function Settings() {
                 </Title>
                 <Stack>
                   <Text size="sm" c="dimmed">
-                    Manage API keys used by integration endpoints. Generating a new key revokes any currently active key.
+                    Manage API keys for your integrations. Each key should have a unique name to identify the app or service it belongs to.
                   </Text>
-                  <Group>
+                  <Group align="flex-end">
+                    <TextInput
+                      label="Key Name"
+                      placeholder="e.g. MyApp1"
+                      value={newKeyName}
+                      onChange={(e) => {
+                        setNewKeyName(e.currentTarget.value);
+                        setNewKeyNameError(null);
+                      }}
+                      error={newKeyNameError}
+                      style={{ flex: 1 }}
+                    />
                     <Button
                       leftSection={<IconKey size={16} />}
-                      onClick={() => generateApiKeyMutation.mutate()}
+                      onClick={handleGenerateApiKey}
                       loading={generateApiKeyMutation.isPending}
                     >
                       Generate API Key
                     </Button>
-                    <Anchor component={Link} to="/settings/api-docs">
-                      <Group gap={6}>
-                        <IconBook size={16} />
-                        <Text size="sm">View API endpoint docs</Text>
-                      </Group>
-                    </Anchor>
                   </Group>
+                  <Anchor component={Link} to="/settings/api-docs">
+                    <Group gap={6}>
+                      <IconBook size={16} />
+                      <Text size="sm">View API endpoint docs</Text>
+                    </Group>
+                  </Anchor>
 
                   {newApiKey && (
                     <Alert color="yellow" title="Store this key now">
@@ -387,7 +415,6 @@ export default function Settings() {
                       <Table.Tr>
                         <Table.Th>Name</Table.Th>
                         <Table.Th>Key</Table.Th>
-                        <Table.Th>Status</Table.Th>
                         <Table.Th>Created</Table.Th>
                         <Table.Th>Last Used</Table.Th>
                         <Table.Th ta="right">Actions</Table.Th>
@@ -396,7 +423,7 @@ export default function Settings() {
                     <Table.Tbody>
                       {apiKeys.length === 0 ? (
                         <Table.Tr>
-                          <Table.Td colSpan={6}>
+                          <Table.Td colSpan={5}>
                             <Text size="sm" c="dimmed">No API keys found.</Text>
                           </Table.Td>
                         </Table.Tr>
@@ -407,13 +434,6 @@ export default function Settings() {
                             <Table.Td>
                               <Code>{apiKey.keyPrefix}...{apiKey.keyLastFour}</Code>
                             </Table.Td>
-                            <Table.Td>
-                              {apiKey.revokedAt ? (
-                                <Badge color="gray">Revoked</Badge>
-                              ) : (
-                                <Badge color="green">Active</Badge>
-                              )}
-                            </Table.Td>
                             <Table.Td>{DateTime.fromISO(apiKey.createdAt).toFormat('dd LLL yyyy')}</Table.Td>
                             <Table.Td>
                               {apiKey.lastUsedAt
@@ -421,16 +441,14 @@ export default function Settings() {
                                 : '-'}
                             </Table.Td>
                             <Table.Td ta="right">
-                              {!apiKey.revokedAt && (
-                                <ActionIcon
-                                  color="red"
-                                  variant="subtle"
-                                  onClick={() => handleOpenDeleteModal(apiKey)}
-                                  aria-label="Delete API key"
-                                >
-                                  <IconTrash size={16} />
-                                </ActionIcon>
-                              )}
+                              <ActionIcon
+                                color="red"
+                                variant="subtle"
+                                onClick={() => handleOpenDeleteModal(apiKey)}
+                                aria-label="Delete API key"
+                              >
+                                <IconTrash size={16} />
+                              </ActionIcon>
                             </Table.Td>
                           </Table.Tr>
                         ))
@@ -464,7 +482,8 @@ export default function Settings() {
       >
         <Text mb="md">
           Are you sure you want to delete API key{' '}
-          <Code>{deletingApiKey?.keyPrefix}...{deletingApiKey?.keyLastFour}</Code>?
+          <strong>{deletingApiKey?.name}</strong>{' '}
+          (<Code>{deletingApiKey?.keyPrefix}...{deletingApiKey?.keyLastFour}</Code>)?
           This action cannot be undone.
         </Text>
         <Group justify="flex-end">

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -17,20 +17,37 @@ import {
   Code,
   List,
   Paper,
+  Anchor,
+  Table,
+  Badge,
+  ActionIcon,
+  Modal,
+  Tabs,
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
+import { useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
-import { IconDeviceFloppy, IconInfoCircle } from '@tabler/icons-react';
+import { IconDeviceFloppy, IconInfoCircle, IconKey, IconBook, IconTrash } from '@tabler/icons-react';
 import { settingsApi } from '../services/api';
 import { DateTime } from 'luxon';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { ApiKeySummary } from '../types';
 
 export default function Settings() {
   const queryClient = useQueryClient();
+  const [newApiKey, setNewApiKey] = useState<string | null>(null);
+  const [deleteModalOpened, { open: openDeleteModal, close: closeDeleteModal }] = useDisclosure(false);
+  const [deletingApiKey, setDeletingApiKey] = useState<ApiKeySummary | null>(null);
 
   const { data: settings, isLoading } = useQuery({
     queryKey: ['settings'],
     queryFn: settingsApi.get,
+  });
+
+  const { data: apiKeyData } = useQuery({
+    queryKey: ['api-keys'],
+    queryFn: settingsApi.getApiKeys,
   });
 
   const form = useForm({
@@ -71,11 +88,85 @@ export default function Settings() {
     },
   });
 
+  const generateApiKeyMutation = useMutation({
+    mutationFn: settingsApi.generateApiKey,
+    onSuccess: (data) => {
+      setNewApiKey(data.apiKey);
+      queryClient.invalidateQueries({ queryKey: ['api-keys'] });
+      notifications.show({
+        title: 'API key generated',
+        message: 'Your previous active key was revoked. Save this new key now.',
+        color: 'green',
+      });
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: 'Error',
+        message: error.message,
+        color: 'red',
+      });
+    },
+  });
+
+  const deleteApiKeyMutation = useMutation({
+    mutationFn: settingsApi.deleteApiKey,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['api-keys'] });
+      notifications.show({
+        title: 'Success',
+        message: 'API key deleted successfully',
+        color: 'green',
+      });
+      closeDeleteModal();
+      setDeletingApiKey(null);
+    },
+    onError: (error: Error) => {
+      notifications.show({
+        title: 'Error',
+        message: error.message,
+        color: 'red',
+      });
+    },
+  });
+
   const handleSubmit = form.onSubmit((values) => {
     updateMutation.mutate(values);
   });
 
-  // Generate preview of footer with sample data
+  const handleCopyApiKey = async () => {
+    if (!newApiKey) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(newApiKey);
+      notifications.show({
+        title: 'Copied',
+        message: 'API key copied to clipboard',
+        color: 'green',
+      });
+    } catch {
+      notifications.show({
+        title: 'Copy failed',
+        message: 'Unable to copy API key from this browser',
+        color: 'red',
+      });
+    }
+  };
+
+  const handleOpenDeleteModal = (apiKey: ApiKeySummary) => {
+    setDeletingApiKey(apiKey);
+    openDeleteModal();
+  };
+
+  const handleDeleteApiKey = () => {
+    if (!deletingApiKey) {
+      return;
+    }
+
+    deleteApiKeyMutation.mutate(deletingApiKey.id);
+  };
+
   const footerPreview = useMemo(() => {
     const text = form.values.invoiceFooterMarkdown || '';
     if (!text) return '';
@@ -93,8 +184,6 @@ export default function Settings() {
 
     let result = text;
     Object.entries(sampleVariables).forEach(([key, value]) => {
-      // Simple string replacement for preview only - not used in actual PDF generation
-      // The backend uses proper template replacement with server-side validation
       result = result.replace(new RegExp(key.replace(/[{}]/g, '\\$&'), 'g'), value);
     });
 
@@ -121,6 +210,8 @@ export default function Settings() {
     });
   }
 
+  const apiKeys = apiKeyData?.keys || [];
+
   return (
     <Container size="md">
       <Title order={1} mb="xl">
@@ -129,132 +220,225 @@ export default function Settings() {
 
       <form onSubmit={handleSubmit}>
         <Stack gap="xl">
-          <Card shadow="sm" padding="lg">
-            <Title order={3} mb="md">
-              Company Information
-            </Title>
-            <Text size="sm" c="dimmed" mb="md">
-              This information will appear on your invoices
-            </Text>
-            <Stack>
-              <TextInput
-                label="Company Name"
-                placeholder="Your Company Name"
-                required
-                {...form.getInputProps('companyName')}
-              />
-              <Textarea
-                label="Company Address"
-                placeholder="123 Main St, City, Country"
-                rows={3}
-                {...form.getInputProps('companyAddress')}
-              />
-              <TextInput
-                label="Company Email"
-                placeholder="billing@company.com"
-                type="email"
-                {...form.getInputProps('companyEmail')}
-              />
-              <TextInput
-                label="Company Phone"
-                placeholder="+1 234 567 8900"
-                {...form.getInputProps('companyPhone')}
-              />
-            </Stack>
-          </Card>
+          <Tabs defaultValue="companyInfo">
+            <Tabs.List>
+              <Tabs.Tab value="companyInfo">Company Info</Tabs.Tab>
+              <Tabs.Tab value="invoiceSettings">Invoice Settings</Tabs.Tab>
+              <Tabs.Tab value="apiKeys">API Key</Tabs.Tab>
+            </Tabs.List>
 
-          <Card shadow="sm" padding="lg">
-            <Title order={3} mb="md">
-              Invoice Settings
-            </Title>
-            <Stack>
-              <NumberInput
-                label="Next Invoice Number"
-                description="The next invoice will use this number and increment from here"
-                placeholder="1"
-                required
-                min={1}
-                {...form.getInputProps('nextInvoiceNumber')}
-              />
-              
-              <div>
-                <Textarea
-                  label="Invoice Footer (Markdown)"
-                  description="Use markdown formatting and template variables. This will appear at the bottom of invoices."
-                  placeholder="e.g., **Payment Terms:** Net 30 days. Please quote **{INVOICE_NO}** in all payments."
-                  rows={6}
-                  {...form.getInputProps('invoiceFooterMarkdown')}
-                />
-                
-                <Alert 
-                  icon={<IconInfoCircle />} 
-                  title="Available Template Variables" 
-                  color="blue" 
-                  mt="md"
-                >
-                  <Text size="sm" mb="xs">
-                    You can use these variables in your invoice footer. They will be replaced with actual values when generating invoices:
+            <Tabs.Panel value="companyInfo" pt="md">
+              <Card shadow="sm" padding="lg">
+                <Title order={3} mb="md">
+                  Company Information
+                </Title>
+                <Text size="sm" c="dimmed" mb="md">
+                  This information will appear on your invoices
+                </Text>
+                <Stack>
+                  <TextInput
+                    label="Company Name"
+                    placeholder="Your Company Name"
+                    required
+                    {...form.getInputProps('companyName')}
+                  />
+                  <Textarea
+                    label="Company Address"
+                    placeholder="123 Main St, City, Country"
+                    rows={3}
+                    {...form.getInputProps('companyAddress')}
+                  />
+                  <TextInput
+                    label="Company Email"
+                    placeholder="billing@company.com"
+                    type="email"
+                    {...form.getInputProps('companyEmail')}
+                  />
+                  <TextInput
+                    label="Company Phone"
+                    placeholder="+1 234 567 8900"
+                    {...form.getInputProps('companyPhone')}
+                  />
+                  <Divider />
+                  <TextInput
+                    label="Timezone"
+                    description="e.g., Pacific/Auckland, America/New_York"
+                    placeholder="Pacific/Auckland"
+                    {...form.getInputProps('timezone')}
+                  />
+                </Stack>
+              </Card>
+            </Tabs.Panel>
+
+            <Tabs.Panel value="invoiceSettings" pt="md">
+              <Card shadow="sm" padding="lg">
+                <Title order={3} mb="md">
+                  Invoice Settings
+                </Title>
+                <Stack>
+                  <NumberInput
+                    label="Next Invoice Number"
+                    description="The next invoice will use this number and increment from here"
+                    placeholder="1"
+                    required
+                    min={1}
+                    {...form.getInputProps('nextInvoiceNumber')}
+                  />
+
+                  <div>
+                    <Textarea
+                      label="Invoice Footer (Markdown)"
+                      description="Use markdown formatting and template variables. This will appear at the bottom of invoices."
+                      placeholder="e.g., **Payment Terms:** Net 30 days. Please quote **{INVOICE_NO}** in all payments."
+                      rows={6}
+                      {...form.getInputProps('invoiceFooterMarkdown')}
+                    />
+
+                    <Alert
+                      icon={<IconInfoCircle />}
+                      title="Available Template Variables"
+                      color="blue"
+                      mt="md"
+                    >
+                      <Text size="sm" mb="xs">
+                        You can use these variables in your invoice footer. They will be replaced with actual values when generating invoices:
+                      </Text>
+                      <List size="sm" spacing="xs">
+                        <List.Item>
+                          <Code>{'{INVOICE_NO}'}</Code> - Invoice number (e.g., INV-0123)
+                        </List.Item>
+                        <List.Item>
+                          <Code>{'{INVOICE_DATE}'}</Code> - Invoice date (e.g., 15 Jan 2025)
+                        </List.Item>
+                        <List.Item>
+                          <Code>{'{CLIENT_NAME}'}</Code> - Customer/client name
+                        </List.Item>
+                        <List.Item>
+                          <Code>{'{TOTAL_AMOUNT}'}</Code> - Total invoice amount (e.g., NZD 1,500.00)
+                        </List.Item>
+                        <List.Item>
+                          <Code>{'{DATE}'}</Code> - Current date when PDF is generated
+                        </List.Item>
+                        <List.Item>
+                          <Code>{'{COMPANY_NAME}'}</Code> - Your company name
+                        </List.Item>
+                        <List.Item>
+                          <Code>{'{COMPANY_ADDRESS}'}</Code> - Your company address
+                        </List.Item>
+                      </List>
+                    </Alert>
+
+                    {footerPreview && (
+                      <Paper p="md" mt="md" withBorder>
+                        <Text size="sm" fw={500} mb="xs">
+                          Preview (with sample data):
+                        </Text>
+                        <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
+                          {footerPreview}
+                        </Text>
+                      </Paper>
+                    )}
+                  </div>
+                </Stack>
+              </Card>
+            </Tabs.Panel>
+
+            <Tabs.Panel value="apiKeys" pt="md">
+              <Card shadow="sm" padding="lg">
+                <Title order={3} mb="md">
+                  API Keys
+                </Title>
+                <Stack>
+                  <Text size="sm" c="dimmed">
+                    Manage API keys used by integration endpoints. Generating a new key revokes any currently active key.
                   </Text>
-                  <List size="sm" spacing="xs">
-                    <List.Item>
-                      <Code>{'{INVOICE_NO}'}</Code> - Invoice number (e.g., INV-0123)
-                    </List.Item>
-                    <List.Item>
-                      <Code>{'{INVOICE_DATE}'}</Code> - Invoice date (e.g., 15 Jan 2025)
-                    </List.Item>
-                    <List.Item>
-                      <Code>{'{CLIENT_NAME}'}</Code> - Customer/client name
-                    </List.Item>
-                    <List.Item>
-                      <Code>{'{TOTAL_AMOUNT}'}</Code> - Total invoice amount (e.g., NZD 1,500.00)
-                    </List.Item>
-                    <List.Item>
-                      <Code>{'{DATE}'}</Code> - Current date when PDF is generated
-                    </List.Item>
-                    <List.Item>
-                      <Code>{'{COMPANY_NAME}'}</Code> - Your company name
-                    </List.Item>
-                    <List.Item>
-                      <Code>{'{COMPANY_ADDRESS}'}</Code> - Your company address
-                    </List.Item>
-                  </List>
-                  <Text size="sm" mt="xs" fw={500}>
-                    Example:
-                  </Text>
-                  <Code block mt="xs">
-                    {`**Payment Terms:** Net 30 days
+                  <Group>
+                    <Button
+                      leftSection={<IconKey size={16} />}
+                      onClick={() => generateApiKeyMutation.mutate()}
+                      loading={generateApiKeyMutation.isPending}
+                    >
+                      Generate API Key
+                    </Button>
+                    <Anchor component={Link} to="/settings/api-docs">
+                      <Group gap={6}>
+                        <IconBook size={16} />
+                        <Text size="sm">View API endpoint docs</Text>
+                      </Group>
+                    </Anchor>
+                  </Group>
 
-Please quote invoice number **{INVOICE_NO}** in all payments.`}
-                  </Code>
-                </Alert>
+                  {newApiKey && (
+                    <Alert color="yellow" title="Store this key now">
+                      <Text size="sm" mb="xs">
+                        This is the only time the full API key is shown.
+                      </Text>
+                      <Code block>{newApiKey}</Code>
+                      <Button mt="sm" variant="light" onClick={handleCopyApiKey}>
+                        Copy API Key
+                      </Button>
+                    </Alert>
+                  )}
 
-                {footerPreview && (
-                  <Paper p="md" mt="md" withBorder>
-                    <Text size="sm" fw={500} mb="xs">
-                      Preview (with sample data):
-                    </Text>
-                    <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
-                      {footerPreview}
-                    </Text>
-                  </Paper>
-                )}
-              </div>
-            </Stack>
-          </Card>
-
-          <Card shadow="sm" padding="lg">
-            <Title order={3} mb="md">
-              Regional Settings
-            </Title>
-            <Stack>
-              <TextInput
-                label="Timezone"
-                description="e.g., Pacific/Auckland, America/New_York"
-                placeholder="Pacific/Auckland"
-                {...form.getInputProps('timezone')}
-              />
-            </Stack>
-          </Card>
+                  <Table>
+                    <Table.Thead>
+                      <Table.Tr>
+                        <Table.Th>Name</Table.Th>
+                        <Table.Th>Key</Table.Th>
+                        <Table.Th>Status</Table.Th>
+                        <Table.Th>Created</Table.Th>
+                        <Table.Th>Last Used</Table.Th>
+                        <Table.Th ta="right">Actions</Table.Th>
+                      </Table.Tr>
+                    </Table.Thead>
+                    <Table.Tbody>
+                      {apiKeys.length === 0 ? (
+                        <Table.Tr>
+                          <Table.Td colSpan={6}>
+                            <Text size="sm" c="dimmed">No API keys found.</Text>
+                          </Table.Td>
+                        </Table.Tr>
+                      ) : (
+                        apiKeys.map((apiKey) => (
+                          <Table.Tr key={apiKey.id}>
+                            <Table.Td>{apiKey.name}</Table.Td>
+                            <Table.Td>
+                              <Code>{apiKey.keyPrefix}...{apiKey.keyLastFour}</Code>
+                            </Table.Td>
+                            <Table.Td>
+                              {apiKey.revokedAt ? (
+                                <Badge color="gray">Revoked</Badge>
+                              ) : (
+                                <Badge color="green">Active</Badge>
+                              )}
+                            </Table.Td>
+                            <Table.Td>{DateTime.fromISO(apiKey.createdAt).toFormat('dd LLL yyyy')}</Table.Td>
+                            <Table.Td>
+                              {apiKey.lastUsedAt
+                                ? DateTime.fromISO(apiKey.lastUsedAt).toFormat('dd LLL yyyy HH:mm')
+                                : '-'}
+                            </Table.Td>
+                            <Table.Td ta="right">
+                              {!apiKey.revokedAt && (
+                                <ActionIcon
+                                  color="red"
+                                  variant="subtle"
+                                  onClick={() => handleOpenDeleteModal(apiKey)}
+                                  aria-label="Delete API key"
+                                >
+                                  <IconTrash size={16} />
+                                </ActionIcon>
+                              )}
+                            </Table.Td>
+                          </Table.Tr>
+                        ))
+                      )}
+                    </Table.Tbody>
+                  </Table>
+                </Stack>
+              </Card>
+            </Tabs.Panel>
+          </Tabs>
 
           <Divider />
 
@@ -270,6 +454,26 @@ Please quote invoice number **{INVOICE_NO}** in all payments.`}
           </Group>
         </Stack>
       </form>
+
+      <Modal
+        opened={deleteModalOpened}
+        onClose={closeDeleteModal}
+        title="Delete API Key"
+      >
+        <Text mb="md">
+          Are you sure you want to delete API key{' '}
+          <Code>{deletingApiKey?.keyPrefix}...{deletingApiKey?.keyLastFour}</Code>?
+          This action cannot be undone.
+        </Text>
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeDeleteModal}>
+            Cancel
+          </Button>
+          <Button color="red" onClick={handleDeleteApiKey} loading={deleteApiKeyMutation.isPending}>
+            Delete
+          </Button>
+        </Group>
+      </Modal>
     </Container>
   );
 }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -262,8 +262,10 @@ export default function Settings() {
                   <Divider />
                   <TextInput
                     label="Timezone"
-                    description="e.g., Pacific/Auckland, America/New_York"
+                    description="This timezone is configured on the server via the TZ environment variable and cannot be changed here."
                     placeholder="Pacific/Auckland"
+                    readOnly
+                    disabled
                     {...form.getInputProps('timezone')}
                   />
                 </Stack>

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -60,6 +60,26 @@ describe('API Service Path Validation', () => {
         expect.objectContaining({ method: 'PUT' })
       );
     });
+    it('should call GET /api/settings/api-keys', async () => {
+      await settingsApi.getApiKeys();
+      expect(fetchMock).toHaveBeenCalledWith('/api/settings/api-keys', expect.any(Object));
+    });
+
+    it('should call POST /api/settings/api-keys/generate', async () => {
+      await settingsApi.generateApiKey();
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/settings/api-keys/generate',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    it('should call DELETE /api/settings/api-keys/:id', async () => {
+      await settingsApi.deleteApiKey(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/settings/api-keys/1',
+        expect.objectContaining({ method: 'DELETE' })
+      );
+    });
   });
 
   describe('Clients API', () => {

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -66,7 +66,7 @@ describe('API Service Path Validation', () => {
     });
 
     it('should call POST /api/settings/api-keys/generate', async () => {
-      await settingsApi.generateApiKey();
+      await settingsApi.generateApiKey('My Test Key');
       expect(fetchMock).toHaveBeenCalledWith(
         '/api/settings/api-keys/generate',
         expect.objectContaining({ method: 'POST' })

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -67,9 +67,10 @@ export const settingsApi = {
 
   getApiKeys: () => fetchApi<ApiKeyListResponse>('/settings/api-keys'),
 
-  generateApiKey: () =>
+  generateApiKey: (name: string) =>
     fetchApi<GeneratedApiKeyResponse>('/settings/api-keys/generate', {
       method: 'POST',
+      body: JSON.stringify({ name }),
     }),
 
   deleteApiKey: (id: number) =>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -11,6 +11,8 @@ import type {
   ReportData,
   ImportPreview,
   ImportResult,
+  ApiKeyListResponse,
+  GeneratedApiKeyResponse,
 } from '../types';
 
 const API_BASE = '/api';
@@ -56,11 +58,23 @@ export const authApi = {
 // Settings API
 export const settingsApi = {
   get: () => fetchApi<Settings>('/settings'),
-  
+
   update: (data: Partial<Settings>) =>
     fetchApi<Settings>('/settings', {
       method: 'PUT',
       body: JSON.stringify(data),
+    }),
+
+  getApiKeys: () => fetchApi<ApiKeyListResponse>('/settings/api-keys'),
+
+  generateApiKey: () =>
+    fetchApi<GeneratedApiKeyResponse>('/settings/api-keys/generate', {
+      method: 'POST',
+    }),
+
+  deleteApiKey: (id: number) =>
+    fetchApi<{ success: boolean }>(`/settings/api-keys/${id}`, {
+      method: 'DELETE',
     }),
 };
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -11,6 +11,30 @@ export interface Settings {
   updatedAt: string;
 }
 
+
+export interface ApiKeySummary {
+  id: number;
+  name: string;
+  keyPrefix: string;
+  keyLastFour: string;
+  createdAt: string;
+  lastUsedAt?: string | null;
+  revokedAt?: string | null;
+}
+
+export interface ApiKeyListResponse {
+  keys: ApiKeySummary[];
+  hasActiveKey: boolean;
+}
+
+export interface GeneratedApiKeyResponse {
+  apiKey: string;
+  keyPrefix: string;
+  keyLastFour: string;
+  createdAt: string;
+  warning: string;
+}
+
 export interface Client {
   id: number;
   name: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -19,16 +19,15 @@ export interface ApiKeySummary {
   keyLastFour: string;
   createdAt: string;
   lastUsedAt?: string | null;
-  revokedAt?: string | null;
 }
 
 export interface ApiKeyListResponse {
   keys: ApiKeySummary[];
-  hasActiveKey: boolean;
 }
 
 export interface GeneratedApiKeyResponse {
   apiKey: string;
+  name: string;
   keyPrefix: string;
   keyLastFour: string;
   createdAt: string;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:debug": "playwright test --debug",
-    "test:e2e:report": "playwright show-report"
+    "test:e2e:report": "playwright show-report",
+    "precommit": "./scripts/precommit.sh"
   },
   "keywords": [],
   "author": "",

--- a/scripts/precommit.sh
+++ b/scripts/precommit.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# precommit.sh — Final check before pushing code for a PR.
+# Runs TypeScript type checking, build verification, and Docker build.
+#
+# Usage: bun run precommit
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+FAILED=0
+STEP=0
+
+step() {
+  STEP=$((STEP + 1))
+  echo ""
+  echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+  echo -e "${BLUE}  Step $STEP: $1${NC}"
+  echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+}
+
+pass() {
+  echo -e "${GREEN}  ✓ $1${NC}"
+}
+
+fail() {
+  echo -e "${RED}  ✗ $1${NC}"
+  FAILED=1
+}
+
+SECONDS=0
+
+echo -e "${YELLOW}╔══════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${YELLOW}║              Precommit Checks                              ║${NC}"
+echo -e "${YELLOW}╚══════════════════════════════════════════════════════════════╝${NC}"
+
+# ── 1. Backend TypeScript type check ──────────────────────────────────────────
+step "Backend TypeScript type check (tsc)"
+if (cd "$ROOT_DIR/backend" && bun run build); then
+  pass "Backend TypeScript — no type errors"
+else
+  fail "Backend TypeScript — type errors found"
+fi
+
+# ── 2. Frontend TypeScript type check ─────────────────────────────────────────
+step "Frontend TypeScript type check (tsc --noEmit)"
+if (cd "$ROOT_DIR/frontend" && npx tsc --noEmit); then
+  pass "Frontend TypeScript — no type errors"
+else
+  fail "Frontend TypeScript — type errors found"
+fi
+
+# ── 3. Frontend Vite build ────────────────────────────────────────────────────
+step "Frontend build (vite build)"
+if (cd "$ROOT_DIR/frontend" && bun run build); then
+  pass "Frontend build — success"
+else
+  fail "Frontend build — failed"
+fi
+
+# ── 4. Docker build ──────────────────────────────────────────────────────────
+step "Docker build"
+if (cd "$ROOT_DIR" && docker build -t timesheet-invoice-app:precommit .); then
+  pass "Docker build — success"
+else
+  fail "Docker build — failed"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+DURATION=$SECONDS
+echo ""
+echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+if [ "$FAILED" -eq 0 ]; then
+  echo -e "${GREEN}  ✓ All precommit checks passed! (${DURATION}s)${NC}"
+  echo -e "${GREEN}    Ready to push.${NC}"
+else
+  echo -e "${RED}  ✗ Some precommit checks failed. (${DURATION}s)${NC}"
+  echo -e "${RED}    Please fix the issues above before pushing.${NC}"
+fi
+echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+exit $FAILED


### PR DESCRIPTION
### Motivation
- The Settings page had become long and hard to scan, so grouping related fields into sections improves usability.
- Provide a clear, focused place for API key actions so users can generate/revoke keys without scrolling through other settings.
- Keep the single save action and existing form validation while making the UI easier to navigate.

### Description
- Replaced the long stacked layout with Mantine `Tabs` in `frontend/src/pages/Settings.tsx`, adding panels for `Company Info`, `Invoice Settings`, and `API Key`.
- Moved the `timezone` input into the `Company Info` tab and left invoice number/footer and template preview in `Invoice Settings` so related fields are grouped together.
- Kept all API key functionality intact (generate, reveal one-time key, copy, list, modal-confirm delete) and preserved the global `Save Settings` behavior.
- Minor UI imports and state/hooks were added to support API key flows and tabs (`Tabs`, `useDisclosure`, `useState`, route `Link` to `ApiDocs`).

### Testing
- Built the frontend production bundle with `cd frontend && bun run build`, which completed successfully.
- Launched the dev servers and ran an automated UI check (Playwright) that navigated to `/settings`, opened the `API Key` tab, and captured a screenshot showing the new tabbed layout (artifact: `artifacts/settings-tabs-api-key.png`).
- No unit test changes were required for this UI-only refactor; existing frontend tests remain unaffected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ce1d22b508326a5acadac16a033ce)